### PR TITLE
Changed FullWidthImage according to QA from designer

### DIFF
--- a/src/client/pages/BlogSamplePage1.jsx
+++ b/src/client/pages/BlogSamplePage1.jsx
@@ -5,7 +5,7 @@ import Header from '../../components/molecules/Header/Header';
 const BlogSamplePage = () =>
     <div>
         <figure className="full-width-image full-width-image--no-margin">
-            <img className="full-width-image__image" src="https://placekitten.com/1600/300"  alt="Kitten" />
+            <img className="full-width-image__image" src="https://placekitten.com/1800/550"  alt="Kitten" />
             <figcaption className="caption caption--no-margin-bottom container container--no-padding container--no-margin container--large">
                 Proin eget tortor risus. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Pellentesque in ipsum id orci porta dapibus. Curabitur aliquet quam id dui posuere blandit. Donec rutrum congue leo eget malesuada.
             </figcaption>

--- a/src/client/pages/InformationArticleSample1.jsx
+++ b/src/client/pages/InformationArticleSample1.jsx
@@ -18,7 +18,7 @@ const InformationArticleSample1 = ({ colors }) =>
         <div className="full-width-image full-width-image--with-mask full-width-image--with-content-overlap">
             <img className="full-width-image__image" src="https://placekitten.com/1600/600" />
         </div>
-        <div className="container container--medium container--no-padding container--white-bg container--extra-padding-top">
+        <div className="container container--medium container--no-padding container--white-bg container--extra-padding-top container--overlapping-full-width-image">
             <div className="container container--small">
                 <p>
                     Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Praesent sapien massa, convallis a pellentesque

--- a/src/client/pages/InformationArticleSample3.jsx
+++ b/src/client/pages/InformationArticleSample3.jsx
@@ -11,9 +11,9 @@ const InformationArticleSample3 = () =>
             </p>
         </Header>
         <div className="full-width-image full-width-image--with-mask full-width-image--with-content-overlap">
-            <img className="full-width-image__image" src="https://placekitten.com/1600/600" />
+            <img className="full-width-image__image" src="https://placekitten.com/1440/440" />
         </div>
-        <div className="container container--medium container--no-padding container--extra-margin-bottom container--white-bg container--extra-padding-top">
+        <div className="container container--medium container--no-padding container--extra-margin-bottom container--white-bg container--extra-padding-top container--overlapping-full-width-image">
             <div className="container container--small">
                 <p>
                     Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Proin eget tortor risus. Cras ultricies ligula sed magna dictum porta. Sed porttitor lectus nibh. Sed porttitor lectus nibh.

--- a/src/components/atoms/FullWidthImage/FullWidthImage.html
+++ b/src/components/atoms/FullWidthImage/FullWidthImage.html
@@ -1,5 +1,5 @@
 <figure class="full-width-image">
-    <img class="full-width-image__image" src="https://placekitten.com/1600/300"  alt="Kitten" />
+    <img class="full-width-image__image" src="https://placekitten.com/1440/440"  alt="Kitten" />
     <figcaption class="caption container container--large container--no-padding container--no-margin">
         Proin eget tortor risus. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Pellentesque in ipsum id orci porta dapibus. Curabitur aliquet quam id dui posuere blandit. Donec rutrum congue leo eget malesuada.
     </figcaption>

--- a/src/components/atoms/FullWidthImage/FullWidthImage.md
+++ b/src/components/atoms/FullWidthImage/FullWidthImage.md
@@ -1,3 +1,6 @@
-Status: *in progress*.
+Status: *finished*.
 
-Work remaining: replace the mask with a new, less curvier mask from a designer.
+Recommendations from designers:
+- Images in the size of 1440x440px or the same width/height format seems to be a good size to use in this component.
+- Avoid using images that contains a lot of white color as this will blend in with the content and the user might not differ the picture from the rounded mask or the overlapping content.
+- Images of nature and people are easier to match with this component than portrait images.

--- a/src/components/atoms/FullWidthImage/FullWidthImage.pcss
+++ b/src/components/atoms/FullWidthImage/FullWidthImage.pcss
@@ -4,22 +4,31 @@
     position: relative;
     z-index: -1;
 
-    @media all and (min-width: 28.125em) {
+    @media all and (min-width: 48em) {
         margin: 0 0 1rem 0;
     }
 
-
     &__image {
         display: block;
+        min-height: 150px;
+        object-fit: cover;
         width: 100%;
+
+        @media all and (min-width: 28.125em) {
+            min-height: 300px;
+        }
+
+        @media all and (min-width: 62em) {
+            height: 440px;
+        }
     }
 
-    @media all and (min-width: 28.125em) {
+    @media all and (min-width: 43em) {
         &--with-mask {
             &:after {
                 background: transparent url('/public/icons/full-screen-image-mask.svg') no-repeat bottom left;
-                background-size: 100%;
-                bottom: -1px;
+                background-size: 101%;
+                bottom: -2px;
                 content: "";
                 display: block;
                 height: 100%;
@@ -30,7 +39,7 @@
         }
 
         &--with-content-overlap {
-            margin-bottom: -18%;
+            margin-bottom: -12%;
         }
     }
 

--- a/src/components/atoms/FullWidthImage/FullWidthImage.with-mask.html
+++ b/src/components/atoms/FullWidthImage/FullWidthImage.with-mask.html
@@ -1,3 +1,3 @@
 <div class="full-width-image full-width-image--with-mask">
-    <img class="full-width-image__image" src="https://placekitten.com/1600/400" alt="Kitten" />
+    <img class="full-width-image__image" src="https://placekitten.com/1440/440" alt="Kitten" />
 </div>

--- a/src/components/atoms/FullWidthImage/FullWidthImage.with-overlapping-content.html
+++ b/src/components/atoms/FullWidthImage/FullWidthImage.with-overlapping-content.html
@@ -1,25 +1,25 @@
 <div class="full-width-image full-width-image--with-mask full-width-image--with-content-overlap">
-    <img class="full-width-image__image" src="https://placekitten.com/1600/500" alt="Kitten" />
+    <img class="full-width-image__image" src="https://placekitten.com/1440/440" alt="Kitten" />
 </div>
 
-<div class="container container--medium container--white-bg">
+<div class="container container--medium container--white-bg container--overlapping-full-width-image">
     <div class="container container--small">
         <p>
             If you add the <code>--with-content-overlap</code> CSS class then the
             next piece of content will overlap the image.
         </p>
         <p>
-            It's recommended to wrap the overlapping content in a <code>&lt;div class="main-content"&gt;</code>
-            to make it responsive and <code>&lt;section class="body-text-container"&gt;</code>
+            It's recommended to wrap the overlapping content in a <code>&lt;div class="container"&gt;</code>
+            to make it responsive and <code>&lt;section class="container--small"&gt;</code>
             to give the content a max-width to restrict the line length in the text for readability (accessibility) reasons.
         </p>
         <p>
-            If you also specify the <code>main-content--padding-top</code> CSS class
-            the main-content element will be padded on top. This is solved with a modifier class
+            If you also specify the <code>container--extra-padding-top</code> CSS class
+            the container will be padded on top. This is solved with a modifier class
             because not all elements within the main-content element should have padding on top.
         </p>
         <p>
-            If you specify the <code>main-content--padded-sides</code> CSS class
+            If you specify the <code>container--overlapping-full-width-image</code> CSS class
             the overlapping content will look the same on smaller devices until it wraps
             beneath the image on the smallest devices.
         </p>

--- a/src/components/global.pcss
+++ b/src/components/global.pcss
@@ -46,8 +46,7 @@ body {
     }
 
     &--extra-padding-top {
-
-        @media all and (min-width: 28.125em){
+        @media all and (min-width: 43em){
             padding-top: 2.5rem;
         }
     }
@@ -58,5 +57,11 @@ body {
 
     &--white-bg {
         background-color: var(--white);
+    }
+
+    &--overlapping-full-width-image {
+        @media all and (min-width: 43em){
+            width: 80%;
+        }
     }
 }

--- a/src/unoptimized-icons/full-screen-image-mask.svg
+++ b/src/unoptimized-icons/full-screen-image-mask.svg
@@ -1,4 +1,10 @@
-<svg width="100%" height="100%" viewBox="0 0 1441 271" xmlns="http://www.w3.org/2000/svg">
-  <title>white mask</title>
-  <path d="M -1.00 252.00 C 633.77 216.627 1114.113 132.806 1442.00 -1.00 L 1442.00 271.000 L -1.00 271.000 L -1.00 252.00 Z" fill="#FFF" fill-rule="evenodd"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1417px" height="152px" viewBox="0 0 1417 152" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 47.1 (45422) - http://www.bohemiancoding.com/sketch -->
+    <title>maske@1x</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="QA" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <path d="M1416.28125,-0.0136714374 L1416.28125,151.32175 L-0.28799494,151.32175 C935.129103,111.722827 1401.80746,3.39028335 1416.28125,-0.0136714374 Z" id="maske" fill="#FFFFFF"></path>
+    </g>
 </svg>


### PR DESCRIPTION
Take a look at the "Albatross-skisser" board in inVision. Under the title "QA accordion + buet bilde ++" you can find an overview of the behavior the designers wanted the FullWidthImage to have according to responsivity. This is what these changes contains.  Also added a new mask that isn't as curvy as the last one. Try it and see if you think it seems fluid.