### PR TITLE
Label text and form color fixes

### DIFF
--- a/src/client/pages/FormsSamplePage.jsx
+++ b/src/client/pages/FormsSamplePage.jsx
@@ -63,12 +63,12 @@ const FormsSamplePage = () =>
             <Form action="/get.html" method="GET">
                 <Form.FormRow>
                     <Form.FormColumn>
-                        <TextBoxWithLabel label="Phone Number" type="text" placeholder="number"/>
+                        <TextBoxWithLabel labelText="Phone Number" type="text" placeholder="number"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
                     <Form.FormColumn>
-                        <TextBoxWithLabel label="Password" type="password" placeholder="password"/>
+                        <TextBoxWithLabel labelText="Password" type="password" placeholder="password"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
@@ -88,12 +88,12 @@ const FormsSamplePage = () =>
             }>
                 <Form.FormRow>
                     <Form.FormColumn>
-                        <TextBoxWithLabel label="Phone Number" type="text" placeholder="number"/>
+                        <TextBoxWithLabel labelText="Phone Number" type="text" placeholder="number"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
                     <Form.FormColumn>
-                        <TextBoxWithLabel label="Password" type="password" placeholder="password"/>
+                        <TextBoxWithLabel labelText="Password" type="password" placeholder="password"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
@@ -108,36 +108,36 @@ const FormsSamplePage = () =>
             <Form>
                 <Form.FormRow>
                     <Form.FormColumn>
-                        <TextBoxWithLabel label="Name" type="text" placeholder="name"/>
+                        <TextBoxWithLabel labelText="Name" type="text" placeholder="name"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
                     <Form.FormColumn size="half">
-                        <TextBoxWithLabel label="D.O.B" type="text" placeholder="01/01/2018"/>
+                        <TextBoxWithLabel labelText="D.O.B" type="text" placeholder="01/01/2018"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
                     <Form.FormColumn size="half">
-                        <TextBoxWithLabel label="Telephone" type="text" placeholder="telephone"/>
+                        <TextBoxWithLabel labelText="Telephone" type="text" placeholder="telephone"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
                     <Form.FormColumn>
-                        <TextBoxWithLabel label="Email" type="text" placeholder="email"/>
+                        <TextBoxWithLabel labelText="Email" type="text" placeholder="email"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
                     <Form.FormColumn>
-                        <TextBoxWithLabel label="Address" type="text" placeholder="address"/>
+                        <TextBoxWithLabel labelText="Address" type="text" placeholder="address"/>
                     </Form.FormColumn>
                     <Form.FormColumn>
-                        <TextBoxWithLabel label="Entrance" type="text" placeholder="entrance"/>
-                        <TextBoxWithLabel label="Apt.No." type="text" placeholder="apt. no"/>
+                        <TextBoxWithLabel labelText="Entrance" type="text" placeholder="entrance"/>
+                        <TextBoxWithLabel labelText="Apt.No." type="text" placeholder="apt. no"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
                     <Form.FormColumn size="half">
-                        <TextBoxWithLabel label="Post Code" type="text" placeholder="Post Code"/>
+                        <TextBoxWithLabel labelText="Post Code" type="text" placeholder="Post Code"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>
@@ -147,7 +147,7 @@ const FormsSamplePage = () =>
                 </Form.FormRow>
                 <Form.FormRow>
                     <Form.FormColumn>
-                        <TextBoxWithLabel label="C/O Address" type="text" placeholder="c/o address"/>
+                        <TextBoxWithLabel labelText="C/O Address" type="text" placeholder="c/o address"/>
                     </Form.FormColumn>
                 </Form.FormRow>
                 <Form.FormRow>

--- a/src/components/atoms/Label/Label.jsx
+++ b/src/components/atoms/Label/Label.jsx
@@ -1,28 +1,23 @@
 import React from 'react';
 
-function classNames(additionalClassName, mode) {
+function classNames(additionalClassName, isUsingGrayText) {
     const classNames = ['label'];
 
     if (additionalClassName) {
         classNames.push(additionalClassName);
     }
 
-    if (mode) {
-        classNames.push(`label--${mode}`);
+    if (isUsingGrayText) {
+        classNames.push(`label--gray-text`);
     }
 
     return classNames.join(' ');
 }
 
 /**
- * Status: *in progress*.
+ * Status: *finished*.
  *
- * Labels used with TextBox should appear on top of input element and be in grey color.
- *
- * Labels used with CheckBox, RadioButton and DropDownList (if labelled at all) should appear
- * to the right of the input element and be in black color.
- *
- * TODO: Add correct examples with new CheckBox and TextBox components.
+ * Standard color is black. Labels used with TextBox and DropDownList should appear on top of input element and be in grey color.
  */
 export default class Label extends React.Component {
     constructor(props) {
@@ -30,8 +25,8 @@ export default class Label extends React.Component {
     }
     render() {
         return (
-            <label className={classNames(this.props.className, this.props.mode)}>
-                {this.props.children}
+            <label className={classNames(this.props.className, this.props.isUsingGrayText)}>
+                {this.props.text || this.props.children}
             </label>
         );
     }

--- a/src/components/atoms/Label/Label.jsx.Examples.json
+++ b/src/components/atoms/Label/Label.jsx.Examples.json
@@ -2,21 +2,14 @@
     {
         "name": "Default",
         "props": {
-            "children": "<span>Label</span>"
+            "text": "This is a label"
         }
     },
     {
-        "name": "Label - text on top",
+        "name": "Label - gray text",
         "props": {
-            "children": "<span>Label</span>",
-            "mode": "text-on-top"
-        }
-    },
-    {
-        "name": "Label - text to right",
-        "props": {
-            "children": "<span>Label</span>",
-            "mode": "text-to-right"
+            "text": "This is a gray-text label",
+            "isUsingGrayText": true
         }
     }
 ]

--- a/src/components/atoms/Label/Label.pcss
+++ b/src/components/atoms/Label/Label.pcss
@@ -1,9 +1,7 @@
 .label {
     color: var(--black);
     
-    &--text-on-top {
-        color: var(--dark-grey);
-    }
-    &--text-to-right {
+    &--gray-text {
+        color: var(--dark-grey-2);
     }
 }

--- a/src/components/colors.pcss
+++ b/src/components/colors.pcss
@@ -1,13 +1,9 @@
 /* Telia Company Brand colors. Try to use these instead of custom ones */
 :root {
+    --black: #000000;
     --white: #FFFFFF;
     --light-grey: #F2F2F2;
-    --grey: #DEDEDE;
-
-    --dark-grey: #A0A0A0;
-    --dark-grey-2: #726E6E;
-    --black: #000000;
-
+    
     --core-purple: #990AE3;
     --dark-core-purple: #9B009B;
     --light-core-purple: #CC00FF;
@@ -29,6 +25,7 @@
     --light-green: #00FF64;
 
     --lime: #CDFF32;
+    --dark-grey: #A0A0A0;
     --light-lime: #CDFF99;
 
     --pink: #FF00CD;
@@ -36,6 +33,7 @@
     --light-pink: #FF64CD;
 
     --orange: #FF9B00;
+    --dark-grey-2: #726E6E;
     --light-orange: #FFCD65;
 
     --red: #FF3264;
@@ -45,6 +43,8 @@
 
 /* Custom colours. Try to add as few as possible new ones, and pick from the Telia Company Brand colors above. */
 :root {
+    --grey: #DEDEDE;
+
     --emerald: #3ED35F;
     --venetian-red: #D0021B;
     --alert-red: #ffd3e0;
@@ -54,5 +54,4 @@
     --alert-dark-yellow: #ffcd64;
     --alert-blue: #e5f4ff;
     --alert-dark-blue: #0099ff;
-
 }

--- a/src/components/molecules/CheckBoxWithLabel/CheckBoxWithLabel.jsx
+++ b/src/components/molecules/CheckBoxWithLabel/CheckBoxWithLabel.jsx
@@ -9,7 +9,7 @@ import Label from '../../atoms/Label/Label';
  * Waiting on the Photoshop files to get the exact checkmark SVG.
  */
 const CheckBoxWithLabel = ({ label, checked }) =>
-    <Label className="check-box-with-label" mode="text-to-right">
+    <Label className="check-box-with-label">
         <input className="check-box-with-label__input" type="checkbox" defaultChecked={checked} />
         <span className="check-box-with-label__svg-container">
             <svg className="check-box-with-label__svg" width="20px" height="20px" viewBox="0 0 20 20">

--- a/src/components/molecules/DropDownListWithLabel/DropDownListWithLabel.jsx
+++ b/src/components/molecules/DropDownListWithLabel/DropDownListWithLabel.jsx
@@ -2,7 +2,17 @@ import React from 'react';
 
 import Label from '../../atoms/Label/Label';
 
-function classNames(labelMode) {
+function labelClassNames(labelMode) {
+    const classNames = ['dropdown-list-with-label'];
+
+    if (labelMode === 'text-to-right') {
+        classNames.push(`dropdown-list-with-label--text-to-right`);
+    }
+
+    return classNames.join(' ');
+}
+
+function dropDownClassNames(labelMode) {
     const classNames = ['dropdown-list-with-label__select'];
 
     if (labelMode === 'text-to-right') {
@@ -18,15 +28,19 @@ function classNames(labelMode) {
  * TODO: Label accessibility. It's recommended to use aria-label on form elements when a label is not visible on the screen.
  **/
 export default class DropDownListWithLabel extends React.Component {
-    constructor(props){
+    constructor(props) {
         super(props);
     }
     render() {
+        const isUsingGrayText = (this.props.labelMode !== 'text-to-right');
+
         return (
-            <Label className="dropdown-list-with-label" mode={this.props.labelMode || 'text-on-top'}>
+            <Label className={labelClassNames(this.props.labelMode)} isUsingGrayText={isUsingGrayText}>
                 {this.props.label ? <span className="dropdown-list-with-label__label-text">{this.props.label}</span> : null}
-                <select className={classNames(this.props.labelMode)}
-                    defaultValue={this.props.selectedOption} onChange={this.props.changeSelectedOption}>
+                <select
+                    className={dropDownClassNames(this.props.labelMode)}
+                    defaultValue={this.props.selectedOption}
+                    onChange={this.props.changeSelectedOption}>
                     {this.props.options.map((option) =>
                         <option className="dropdown-list-with-label__option" key={option}>
                             {option}

--- a/src/components/molecules/DropDownListWithLabel/DropDownListWithLabel.jsx.Examples.json
+++ b/src/components/molecules/DropDownListWithLabel/DropDownListWithLabel.jsx.Examples.json
@@ -13,9 +13,8 @@
         }
     },
     {
-        "name": "With label on the top",
+        "name": "Default - Gray label text on the top",
         "props": {
-            "labelMode": "text-on-top",
             "options": [
                 "Apple iPhone 6 128 GB",
                 "Apple iPhone 7 128 GB",

--- a/src/components/molecules/DropDownListWithLabel/DropDownListWithLabel.pcss
+++ b/src/components/molecules/DropDownListWithLabel/DropDownListWithLabel.pcss
@@ -1,10 +1,12 @@
 .dropdown-list-with-label {
+    align-items: left;
     display: flex;
+    flex-direction: column;
 
     &__select {
         background: transparent url('/public/icons/ico_dropArrow.svg') no-repeat right 10px center;
         background-size: 15px 15px;
-        border: 1px solid var(--grey);
+        border: 1px solid var(--dark-grey-2);
         border-radius: 0;
         font-size: 1rem;
         margin: 0;
@@ -32,8 +34,9 @@
         padding: 0;
     }
 
-    &.label--text-to-right {
+    &--text-to-right {
         align-items: center;
+        flex-direction: row;
 
         .dropdown-list-with-label__label-text {
             order: 2;
@@ -42,19 +45,6 @@
 
         .dropdown-list-with-label__select {
             order: 1;
-        }
-    }
-
-    &.label--text-on-top {
-        flex-direction: column;
-        align-items: left;
-
-        .dropdown-list-with-label__label-text {
-            order: 1;
-        }
-
-        .dropdown-list-with-label__select {
-            order: 2;
         }
     }
 }

--- a/src/components/molecules/RadioButtonList/RadioButtonWithLabel.jsx
+++ b/src/components/molecules/RadioButtonList/RadioButtonWithLabel.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Label from '../../atoms/Label/Label';
 
 const RadioButtonWithLabel = ({ label, checked, name, value }) =>
-    <Label className="radio-button-with-label" mode="text-to-right">
+    <Label className="radio-button-with-label">
         <input
             className="radio-button-with-label__input"
             type="radio"

--- a/src/components/molecules/TextBoxWithLabel/TextBoxWithLabel.jsx
+++ b/src/components/molecules/TextBoxWithLabel/TextBoxWithLabel.jsx
@@ -9,9 +9,9 @@ import Label from '../../atoms/Label/Label';
  * the user to give correct input.
  *
 **/
-const TextBoxWithLabel = ({ label, type, placeholder}) =>
-    <Label className="textbox-with-label" mode="text-on-top">
-        <span className="textbox-with-label__label-text">{label}</span>
+const TextBoxWithLabel = ({ labelText, type, placeholder}) =>
+    <Label className="textbox-with-label" isUsingGrayText={true}>
+        <span className="textbox-with-label__label-text">{labelText}</span>
         <input className="textbox-with-label__input" type={type} placeholder={placeholder} />
     </Label>;
 

--- a/src/components/molecules/TextBoxWithLabel/TextBoxWithLabel.jsx.Examples.json
+++ b/src/components/molecules/TextBoxWithLabel/TextBoxWithLabel.jsx.Examples.json
@@ -2,7 +2,7 @@
     {
         "name": "Type Text",
         "props": {
-            "label": "Label for textbox",
+            "labelText": "Label for textbox",
             "type": "text",
             "placeholder": "Write here.."
         }

--- a/src/components/molecules/TextBoxWithLabel/TextBoxWithLabel.pcss
+++ b/src/components/molecules/TextBoxWithLabel/TextBoxWithLabel.pcss
@@ -1,6 +1,10 @@
 .textbox-with-label {
+    ::placeholder {
+        color: var(--dark-grey);
+    }
+
     &__input {
-        border: 1px solid var(--grey);
+        border: 1px solid var(--dark-grey-2);
         color: var(--black);
         font: inherit;
         padding: 10px 15px;

--- a/src/components/organisms/Form/Form.jsx
+++ b/src/components/organisms/Form/Form.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 /**
  *
- * The layout of a form is created by nesting form\_\_row and form\_\_column.
+ * The layout of a form is created by nesting `form__row` and `form__column`. 
  * Inside each column you add the components you need for creating your own form.
  *
- * More form examples <a href="/forms">here</a>.
+ * More form examples on the <a href="/forms">forms sample page</a>.
  */
 class Form extends React.Component {
     constructor(props) {

--- a/src/components/organisms/Form/Form.jsx.Examples.json
+++ b/src/components/organisms/Form/Form.jsx.Examples.json
@@ -4,7 +4,7 @@
      "props": {
          "action": "POST",
          "children": [
-             "<div class=\"form__row\"><div class=\"form__column \"><label class=\"label textbox-with-label label--text-on-top\"><span class=\"textbox-with-label__label-text\">Phone Number</span><input type=\"text\" class=\"textbox-with-label__input\" placeholder=\"number\"></label></div></div><div class=\"form__row\"><div class=\"form__column \"><label class=\"label textbox-with-label label--text-on-top\"><span class=\"textbox-with-label__label-text\">Password</span><input type=\"password\" class=\"textbox-with-label__input\" placeholder=\"password\"></label></div></div><div class=\"form__row\"><button class=\"button\">Login</button>"
+             "<div class=\"form__row\"><div class=\"form__column \"><label class=\"label label--gray-text textbox-with-label\"><span class=\"textbox-with-label__label-text\">Phone Number</span><input type=\"text\" class=\"textbox-with-label__input\" placeholder=\"number\"></label></div></div><div class=\"form__row\"><div class=\"form__column \"><label class=\"label label--gray-text textbox-with-label\"><span class=\"textbox-with-label__label-text\">Password</span><input type=\"password\" class=\"textbox-with-label__input\" placeholder=\"password\"></label></div></div><div class=\"form__row\"><button class=\"button\">Login</button>"
          ]
      }
     }


### PR DESCRIPTION
- `Label` doesn't have any "text-to-right" or anything else related to positioning. Only default, or gray text.
- `Label` can have `text` props or `children` passed in, to support simple labels or complex ones with child elements.
- `TextBoxWithLabel` has its `label` props renamed to `labelText`.
- `colors.pcss` matches the color grid we see in the UI.
- `DropDownListWithLabel` defaults to gray text on top.
- `TextBoxWithLabel` defaults to gray text on top.
- Labels, input borders and placeholder text have had their colors tweaked according to UX's wishes, because it was too light and hard to read before.