### PR TITLE
Small fixes to some components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telia-styleguide-poc",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/atoms/Caption/Caption.pcss
+++ b/src/components/atoms/Caption/Caption.pcss
@@ -3,6 +3,7 @@
     font-size: 0.8rem;
     font-style: italic;
     margin-bottom: var(--margin-bottom);
+    margin-top: 0;
     padding: 0.3rem 0.5rem;
 
     &--no-margin-bottom {

--- a/src/components/atoms/Heading/Heading.pcss
+++ b/src/components/atoms/Heading/Heading.pcss
@@ -28,12 +28,11 @@
         font-size: rem(18);
         letter-spacing: rem(0.3);
         line-height: rem(24);
-        margin: rem(50) 0 rem(5) 0;
+        margin: 0 0 rem(5);
 
         @media all and (min-width: em(450)) {
             font-size: rem(21);
             line-height: rem(27);
-            margin: rem(60) 0 rem(5) 0;
         }
     }
 
@@ -42,7 +41,7 @@
         color: var(--black);
         font-size: rem(16);
         line-height: rem(21);
-        margin: rem(30) 0 0;
+        margin: 0;
 
         @media all and (min-width: em(450)) {
             font-size: rem(18);
@@ -55,7 +54,7 @@
         color: var(--black);
         font-size: rem(16);
         line-height: rem(21);
-        margin: rem(30) 0 0;
+        margin: 0;
     }
 
     &--pebble {

--- a/src/components/molecules/AccordionList/AccordionList.pcss
+++ b/src/components/molecules/AccordionList/AccordionList.pcss
@@ -44,7 +44,7 @@
         font-family: inherit;
         font-size: inherit;
         font-weight: inherit;
-        padding: 1rem;
+        padding: 1rem 2.8rem 1rem 1rem;
         position: relative;
         text-align: left;
         width: 100%;

--- a/src/components/molecules/FocusBox/FocusBox.pcss
+++ b/src/components/molecules/FocusBox/FocusBox.pcss
@@ -27,7 +27,7 @@
         padding: 0 20px;
 
         @media screen and (min-width: 28.125em) {
-            padding: 2rem 20px 2rem;
+            padding: 4rem 20px 4rem;
         }
     }
 }

--- a/src/components/molecules/Image/Image.pcss
+++ b/src/components/molecules/Image/Image.pcss
@@ -10,7 +10,6 @@
         .image__img {
             display: block;
             width: inherit;
-            max-width: 100%;
         }
     }
 
@@ -26,6 +25,7 @@
 
     &__img {
         display: block;
-        width: 100%;
+        height: auto;
+        max-width: 100%;
     }
 }

--- a/src/components/molecules/ListWithImage/ListWithImage.pcss
+++ b/src/components/molecules/ListWithImage/ListWithImage.pcss
@@ -75,6 +75,12 @@
     }
 
     &--hide-image-for-mobile {
+        margin-bottom: 0;
+
+        @media all and (min-width: em(640)) {
+            margin-bottom: 40px;
+        }
+
         .list-with-image__image {
             display: none;
 


### PR DESCRIPTION
- Set margin-top in caption to 0 in case the css class is used on an element that has margin-top
- Removed margin-top on heading components; heading--level-2, 3 and 4
- Increased padding-right on accordion, so text doesn't touch the +/- icon
- Increased padding-top and bottom on FocusBox
- Image in image component is now 100% if bigger than container, if not it's rendered as it's exact size.
- Removing some of the margin on ListWithImage on mobile when the image doesn't show