### PR TITLE
Added description list for term-details list applications e.g. see Ab…

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -15,6 +15,9 @@ For Major and Minor changes in version you must notify everyone in the #stylegui
 
 Only noteworthy versions shown (minor changes are omitted).
 
+## 1.2.6 [new component]
+- Atom: DescriptionList
+
 ## 1.2.5 [changed component]
 - Atom: List - Changed margin-top on list
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telia-styleguide-poc",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/components/atoms/DescriptionList/DescriptionList.html
+++ b/src/components/atoms/DescriptionList/DescriptionList.html
@@ -1,0 +1,6 @@
+<dl class="description-list">
+    <dt class="description-list__term">First term:</dt>
+    <dd class="description-list__details">First description</dd>
+    <dt class="description-list__term">Second term:</dt>
+    <dd class="description-list__details">Second description</dd>
+</dl>

--- a/src/components/atoms/DescriptionList/DescriptionList.md
+++ b/src/components/atoms/DescriptionList/DescriptionList.md
@@ -1,0 +1,1 @@
+Status: *finished*.

--- a/src/components/atoms/DescriptionList/DescriptionList.pcss
+++ b/src/components/atoms/DescriptionList/DescriptionList.pcss
@@ -1,0 +1,42 @@
+.description-list {
+    list-style: none;
+    margin-bottom: 1.5rem;
+    margin-top: 0.5rem;
+    padding-left: 0;
+
+    &__term {
+        font-size: 0.875rem;
+        color: var(--dark-grey-2);
+        padding: 0.25rem 0 0 0;
+    }
+
+    &__details {
+        margin: 0;
+        padding: 0 0 0.32rem 0;
+    }
+
+    &--wrap {
+        display: flex;
+        flex-flow: column wrap;
+
+        > .description-list__term {
+            flex: 1;
+
+            @media all and (min-width: 37.500em) {
+                flex:  33.333333%;
+            }
+        }
+
+        &-by-two {
+            @media all and (min-width: 37.500em) {
+                max-height: 8em;
+            }
+        }
+    }
+
+    &__item {
+        background: transparent url('/public/icons/ico_check.svg') no-repeat left 0.5rem;
+        background-size: 0.875rem 0.875rem;
+        padding: 0.25rem 0 0.25rem 1.25rem;
+    }
+}

--- a/src/components/atoms/DescriptionList/DescriptionList.wrap-by-two.html
+++ b/src/components/atoms/DescriptionList/DescriptionList.wrap-by-two.html
@@ -1,0 +1,10 @@
+<dl class="description-list description-list--wrap description-list--wrap-by-two">
+    <dt class="description-list__term">First term:</dt>
+    <dd class="description-list__details">First description</dd>
+    <dt class="description-list__term">Second term:</dt>
+    <dd class="description-list__details">Second description</dd>
+    <dt class="description-list__term">Third term:</dt>
+    <dd class="description-list__details">Third description</dd>
+    <dt class="description-list__term">Fourth term:</dt>
+    <dd class="description-list__details">Fourth description</dd>
+</dl>


### PR DESCRIPTION
I haven't done CSS for about a decade so I'll just describe my line of thinking:
- By default dd's have a big left margin so I've set margin 0
- Ulrikke said the font size for the dt is 14pt but rems have been used elsewhere so I've used 0.875rem to achieve the same ration between dt and dd
- I've given 0.25rem padding over the dt and 0.32rem padding below the dd which gives slightly more space between each pair than the regular list as in the sketch.