### PR TITLE
Same focus styling on checkbox and radio buttons

### DIFF
--- a/src/components/molecules/CheckBoxWithLabel/CheckBoxWithLabel.jsx.Examples.json
+++ b/src/components/molecules/CheckBoxWithLabel/CheckBoxWithLabel.jsx.Examples.json
@@ -2,14 +2,14 @@
     {
         "name": "Unchecked",
         "props": {
-            "label": "I am checked",
+            "label": "I am not checked",
             "checked": false
         }
     },
     {
         "name": "Checked",
         "props": {
-            "label": "I am not checked",
+            "label": "I am checked",
             "checked": true
         }
     }

--- a/src/components/molecules/CheckBoxWithLabel/CheckBoxWithLabel.pcss
+++ b/src/components/molecules/CheckBoxWithLabel/CheckBoxWithLabel.pcss
@@ -7,6 +7,12 @@
         opacity: 0;
     }
 
+    & .check-box-with-label__input:focus + .check-box-with-label__svg-container {
+        & .check-box-with-label__frame {
+            stroke: var(--core-purple);
+        }
+    }
+
     /* SVG container */
     & .check-box-with-label__svg-container {
         vertical-align: middle;
@@ -18,22 +24,22 @@
     /* SVG parts */
     & .check-box-with-label__frame {
         fill: none;
-        stroke: #808281;
+        stroke: var(--dark-grey-2);
         stroke-width: 2px;
         transition: stroke .3s ease;
     }
     &:hover .check-box-with-label__frame {
-        stroke: #8d16d0;
+        stroke: var(--core-purple);
     }
 
     & .check-box-with-label__check-mark {
         fill: none;
-        stroke: #8d16d0;
+        stroke: var(--core-purple);
         stroke-width: 2;
         stroke-linecap: round;
         stroke-linejoin: round;
         stroke-dasharray: 21px;
-        stroke-dashoffset: 21px;
+        stroke-dashoffset: 21.1px;
         transition: stroke-dashoffset .3s ease;
     }
 

--- a/src/components/molecules/RadioButtonList/RadioButtonList.jsx
+++ b/src/components/molecules/RadioButtonList/RadioButtonList.jsx
@@ -7,9 +7,8 @@ const getClassName = (type) =>
     classnames('radio-button-list', { 'radio-button-list--horizontal' : type === 'horizontal' });
 
 /**
- * Status: *in progress*.
+ * Status: *finished*.
  *
- * Missing styles for focusing
  */
 const RadioButtonList = ({ list, selectedIndex, name, type }) =>
     <div className={getClassName(type)}>

--- a/src/components/molecules/RadioButtonList/RadioButtonWithLabel.jsx
+++ b/src/components/molecules/RadioButtonList/RadioButtonWithLabel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+    import React from 'react';
 
 import Label from '../../atoms/Label/Label';
 

--- a/src/components/molecules/RadioButtonList/RadioButtonWithLabel.pcss
+++ b/src/components/molecules/RadioButtonList/RadioButtonWithLabel.pcss
@@ -6,11 +6,6 @@
     flex-direction: row;
     align-items: start;
 
-    & .radio-button-with-label__input:focus ~ * {
-        background: var(--core-purple);
-        color: var(--white);
-    }
-
     & .radio-button-with-label__input {
         position: absolute;
         opacity: 0;
@@ -30,22 +25,21 @@
     /* SVG parts */
     & .radio-button-with-label__frame {
         fill: none;
-        stroke: #808281;
+        stroke: var(--dark-grey-2);
         stroke-width: 2px;
         transition: stroke .3s ease;
     }
     &:hover .radio-button-with-label__frame {
-        stroke: #8d16d0;
+        stroke: var(--core-purple);
     }
-    & .radio-button-with-label__input:focus ~ * .radio-button-with-label__frame {
-        stroke: var(--white);
-    }
-    &:focus .radio-button-with-label__frame {
-        stroke: var(--white);
+    & .radio-button-with-label__input:focus + .radio-button-with-label__svg-container {
+        & .radio-button-with-label__frame {
+            stroke: var(--core-purple);
+        }
     }
 
     & .radio-button-with-label__check-mark {
-        fill: #8d16d0;
+        fill: var(--core-purple);
         opacity: 0;
         stroke: none;
         transition: opacity .3s ease;
@@ -53,9 +47,6 @@
 
     & .radio-button-with-label__input:checked + .radio-button-with-label__svg-container .radio-button-with-label__check-mark {
         opacity: 1;
-    }
-    & .radio-button-with-label__input:checked:focus ~ * .radio-button-with-label__check-mark {
-        fill: var(--white);
     }
 
     & > .radio-button-with-label__label-text {


### PR DESCRIPTION
- Added focus styling on CheckBox (same as hover-styling)
- There already was a different kind of focus styling on RadioButtons, but I changed it to match CheckBox
- This is what the design in the "Rollover og Tab" sketch says, but it needs review from designer in case the sketch is no longer valid
- DESIGNER REVIEW OK