### PR TITLE
Bugfix for hero

### DIFF
--- a/src/components/molecules/Hero/Hero.pcss
+++ b/src/components/molecules/Hero/Hero.pcss
@@ -193,6 +193,7 @@
         line-height: 27px;
         margin: 0 0 15px;
         text-transform: uppercase;
+        font-weight: normal;
 
         @media all and (min-width: 90em) {
             font-size: 45px;


### PR DESCRIPTION
Fixed issue in Safari on iOS where .hero__heading was rendered with font-weight: bold