### PR TITLE
Provide bundle with commonjs modules

### DIFF
--- a/component-lib/package.json
+++ b/component-lib/package.json
@@ -3,8 +3,8 @@
   "version": "1.7.2",
   "private": false,
   "description": "",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.es.js",
   "scripts": {
     "build:library": "run-p build:library:css build:library:js svgo",
     "build:library:css": "postcss src/index.pcss -o dist/index.css --config ./postcss.config.js",

--- a/component-lib/rollup.build.js
+++ b/component-lib/rollup.build.js
@@ -12,7 +12,8 @@ export default [{
     input: 'src/index.js',
     external: ['react', 'react-dom', 'prop-types'],
     output: [
-        { file: pkg.module, format: 'es', sourcemap: 'inline' }
+        { file: pkg.main, format: 'cjs', sourcemap: 'inline' },
+        { file: pkg.module, format: 'es', sourcemap: 'inline' },
     ],
     plugins: [
         eslint(),


### PR DESCRIPTION
Some project does not transpile their dependencies so they fail to load this library. Let's provide commonjs version, so the library would be easy to use.