### PR TITLE
changed radio button defaultChecked prop to checked

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,8 @@
         "react/jsx-equals-spacing": ["warn", "never"],
         "react/jsx-no-duplicate-props": ["warn", { "ignoreCase": true }],
         "react/jsx-tag-spacing": ["warn"],
-        "react/jsx-indent-props": ["warn", 4]
+        "react/jsx-indent-props": ["warn", 4],
+        "react/no-array-index-key": "warn" // todo: this should be an "error" really
     },
     "plugins": [
         "react"

--- a/component-lib/src/molecules/RadioButtonList/RadioButtonList.jsx
+++ b/component-lib/src/molecules/RadioButtonList/RadioButtonList.jsx
@@ -18,7 +18,7 @@ const RadioButtonList = ({ list = [], selectedIndex, name, type, hasRichContent,
             : list.map((radio, index) =>
                 <RadioButtonWithLabel
                     checked={index === selectedIndex}
-                    key={index}
+                    key={radio.value}
                     label={radio.label}
                     name={name}
                     onChange={onChange}

--- a/component-lib/src/molecules/RadioButtonList/RadioButtonWithLabel.jsx
+++ b/component-lib/src/molecules/RadioButtonList/RadioButtonWithLabel.jsx
@@ -9,7 +9,7 @@ const RadioButtonWithLabel = ({ label, checked, disabled, name, value, hasRichCo
             className="radio-button-with-label__input"
             type="radio"
             name={name}
-            defaultChecked={checked}
+            checked={checked}
             onChange={onChange ? (changeEvent) => onChange(changeEvent.target.value) : null}
             disabled={disabled}
             value={value} />


### PR DESCRIPTION
- with `defaultChecked` it doesn't update the radio buttons when `selectedIndex` prop has changed
- it caused even more failures when `key={index}`
- so I added `react/no-array-index-key` lint rule which I couldn't set to "error" yet as the key=index is being used on loads of places