### PR TITLE
replaced defaultValue with value prop in <select /> element in <DropDownListWithLabel />

### DIFF
--- a/component-lib/src/molecules/DropDownListWithLabel/DropDownListWithLabel.jsx
+++ b/component-lib/src/molecules/DropDownListWithLabel/DropDownListWithLabel.jsx
@@ -25,7 +25,7 @@ const DropDownListWithLabel = ({ className, labelMode, visibleLabel, label, sele
             className={classnames('dropdown-list-with-label__select', {
                 'dropdown-list-with-label__select--half': labelMode === 'text-to-right'
             })}
-            defaultValue={selectedOption}
+            value={selectedOption}
             onChange={changeSelectedOption}
             aria-label={visibleLabel ? null : label}
             {...rest}>
@@ -36,6 +36,7 @@ const DropDownListWithLabel = ({ className, labelMode, visibleLabel, label, sele
         </select>
     </Label>
 );
+
 DropDownListWithLabel.propTypes = {
     labelMode: PropTypes.oneOf(['text-to-right']),
     visibleLabel: PropTypes.bool,


### PR DESCRIPTION
<DropDownListWithLabel />  is controlled component so it shouldn't have `defaultValue` prop but `value` (https://reactjs.org/docs/forms.html#controlled-components). With current `defaultValue` the select options won't update when `value` prop has changed
