### PR TITLE
Restructure components by Category

### DIFF
--- a/component-lib/src/atoms/AlertText/AlertText.jsx
+++ b/component-lib/src/atoms/AlertText/AlertText.jsx
@@ -5,6 +5,7 @@ import Heading from '../Heading';
 
 /**
  * Status: *finished*.
+ * Category: Notifications
  *
  * Use this component when you want to make the user aware of something, for instance:
  * - the chat to customer service is closed

--- a/component-lib/src/atoms/AnimatedProgressBar/AnimatedProgressBar.jsx
+++ b/component-lib/src/atoms/AnimatedProgressBar/AnimatedProgressBar.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*.
+ * Category: Loader
  *
  * An animated progress bar with changeable bar and background color.
  * Basically copied from https://codepen.io/holdencreative/pen/vEVbwv with some modifications

--- a/component-lib/src/atoms/Box/Box.jsx
+++ b/component-lib/src/atoms/Box/Box.jsx
@@ -5,13 +5,14 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *finished*.
+ * Category: Boxes
  *
  * A Box component has a default size, but can be made into a small or a medium box.
  * It serves as a container with a colored border, and do not have any padding since the content
  * should be able to control that part.
  *
  * One or more Boxes can be used inside a <a href="/components/molecules#BoxGrid">BoxGrid</a> component.
- * 
+ *
  * Color can be set to transparent with box--no-background
  */
 export default class Box extends React.Component {

--- a/component-lib/src/atoms/Button/Button.jsx
+++ b/component-lib/src/atoms/Button/Button.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*.
+ * Category: Buttons
  */
 const Button = ({ text, kind, size, onClick, className, processingText, isProcessing, isDisabled, type = 'button', margin, ...rest }) =>
     <button

--- a/component-lib/src/atoms/Caption/Caption.jsx
+++ b/component-lib/src/atoms/Caption/Caption.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*.
+ * Category: ImageAndVideo
  */
 const Caption = ({ className, children, ...rest }) => (
     <div

--- a/component-lib/src/atoms/Container/Container.jsx
+++ b/component-lib/src/atoms/Container/Container.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *in progress*
+ * Category: Misc
  *
  * There are three main container widths: small, medium and large. Body text, such as this one, should be in a small container to reduce line width and make reading easier.
  */

--- a/component-lib/src/atoms/DescriptionList/DescriptionList.jsx
+++ b/component-lib/src/atoms/DescriptionList/DescriptionList.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Style
  */
 const DescriptionList = ({ children, wrapByTwo, className, ...rest }) => {
     return (

--- a/component-lib/src/atoms/FullWidthTable/FullWidthTable.jsx
+++ b/component-lib/src/atoms/FullWidthTable/FullWidthTable.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Tables
  *
  * This table component use negative margins to achieve full width rows in the table,
  * and padding to add back the negative margin value. To avoid horizontal scrolling

--- a/component-lib/src/atoms/Heading/Heading.jsx
+++ b/component-lib/src/atoms/Heading/Heading.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*.
+ * Category: Style
  *
  * The Heading component should be used for page titles, sub-titles, etc.
  * Currently, only h1, h2, h3 and h4 headings have been defined.
@@ -11,7 +12,7 @@ import classnames from 'classnames';
  * Margin for headings should be handled in the components that make use of this component.
  * See <a href='/information-article-5' class='link'>this sample page</a> that make use of the
  * <a href='/components/molecules#RichText' class='link'>RichText component</a> to style headings in running text.
- * 
+ *
  * Heading can be centered by applying heading--centered.
  */
 const Heading = ({ level, text, children, className, ...rest }) => {

--- a/component-lib/src/atoms/HorizontalRule/HorizontalRule.jsx
+++ b/component-lib/src/atoms/HorizontalRule/HorizontalRule.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Misc
  *
  * The css-class <code>.horizontal-rule</code> can be used on any element to give it a grey border in bottom of
  * the element, or it can be used on the <code>&lt;hr/&gt;</code> tag as a standalone component.

--- a/component-lib/src/atoms/IconAnimated/IconAnimated.jsx
+++ b/component-lib/src/atoms/IconAnimated/IconAnimated.jsx
@@ -4,6 +4,7 @@ import lottie from 'lottie-web';
 
 /**
  * Status: *finished*.
+ * Category: Style
  */
 
 export default class IconAnimated extends React.Component {

--- a/component-lib/src/atoms/IconLink/IconLink.jsx
+++ b/component-lib/src/atoms/IconLink/IconLink.jsx
@@ -6,6 +6,7 @@ import upperFirst from 'lodash/upperFirst';
 
 /**
  * Status: *finished*.
+ * Category: Links
  */
 const IconLink = ({ className, iconName, ...rest }) => (
     <a

--- a/component-lib/src/atoms/InputError/InputError.jsx
+++ b/component-lib/src/atoms/InputError/InputError.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: FormElements
  */
 const InputError = ({ className, children, ...rest }) => (
     <span

--- a/component-lib/src/atoms/Label/Label.jsx
+++ b/component-lib/src/atoms/Label/Label.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: FormElements
  *
  * Standard color is black. Labels used with TextBoxWithLabel, TextAreaWithLabel and DropDownListWithLabel should appear on top of input element and be in grey color.
  */

--- a/component-lib/src/atoms/Link/Link.jsx
+++ b/component-lib/src/atoms/Link/Link.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*.
+ * Category: Links
  *
  * The target attribute is set to '_self' which is the default value if the attribute is not specified.
  * If you rather prefer to open the linked document in a new browser window or tab, you can set the target to '_blank' instead.
@@ -23,7 +24,7 @@ const Link = ({ className, text, children, href, icon, iconPosition, target = '_
         {text}
         {children}
     </a>;
-    
+
 Link.propTypes = {
     /** Content of this link. */
     text: PropTypes.node,

--- a/component-lib/src/atoms/List/List.jsx
+++ b/component-lib/src/atoms/List/List.jsx
@@ -7,6 +7,7 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *finished*
+ * Category: Lists
  */
 const List = ({ children, className, wrapByThree, wrapByFour, black, ...rest }) => {
     // Determine css classes to use based on the children.

--- a/component-lib/src/atoms/PagePebbles/PagePebbles.jsx
+++ b/component-lib/src/atoms/PagePebbles/PagePebbles.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 /**
  * Status: *finished*.
+ * Category: PageElements
+ *
  * <p>
  *   Use the CSS class <code>.page-pebbles</code> if you want pebbles as decoration on your page.
  *   This applies to devices wider than or equal to 900px.

--- a/component-lib/src/atoms/Paragraph/Paragraph.jsx
+++ b/component-lib/src/atoms/Paragraph/Paragraph.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *in progress*.
+ * Category: Style
  *
  * Work remaining:
  *

--- a/component-lib/src/atoms/ProgressBar/ProgressBar.jsx
+++ b/component-lib/src/atoms/ProgressBar/ProgressBar.jsx
@@ -11,6 +11,7 @@ const clamp = (min, max, value) => {
 
 /**
  * Status: *in progress*.
+ * Category: Graphs
  */
 const ProgressBar = ({
     value,

--- a/component-lib/src/atoms/Quote/Quote.jsx
+++ b/component-lib/src/atoms/Quote/Quote.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Style
  */
 const Quote = ({ children, className, inline = false, source, ...rest }) => (
     <blockquote

--- a/component-lib/src/atoms/ShadowBox/ShadowBox.jsx
+++ b/component-lib/src/atoms/ShadowBox/ShadowBox.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Boxes
  */
 const ShadowBox = ({ children, className, ...rest }) => (
     <div

--- a/component-lib/src/atoms/SpecialMessage/SpecialMessage.jsx
+++ b/component-lib/src/atoms/SpecialMessage/SpecialMessage.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Style
  */
 const SpecialMessage = ({ children, className, ...rest }) => (
     <strong

--- a/component-lib/src/atoms/Spinner/Spinner.jsx
+++ b/component-lib/src/atoms/Spinner/Spinner.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 /**
  * Status: *in progress*.
+ * Category: Loader
  *
  * Future work: Replace it with gif
  *

--- a/component-lib/src/atoms/StepIndicator/StepIndicator.jsx
+++ b/component-lib/src/atoms/StepIndicator/StepIndicator.jsx
@@ -6,6 +6,7 @@ import SvgIcon from '../SvgIcon/SvgIcon';
 
 /**
  * Status: *In progress*.
+ * Category: Wizard
  */
 const renderLine = (number, numberOfSteps, index) => {
     if (number >= numberOfSteps - 1) {

--- a/component-lib/src/atoms/SvgIcon/SvgIcon.jsx
+++ b/component-lib/src/atoms/SvgIcon/SvgIcon.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *In progress*.
+ * Category: Style
  *
  * A component that is used to create external reference to svg icons from the icon assets.
  * To show an icon, give the name of the icon (without file ending) and the desired color (defaults to black).

--- a/component-lib/src/atoms/Tags/Tags.jsx
+++ b/component-lib/src/atoms/Tags/Tags.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Links
  */
 const Tags = ({ children, className, color, ...rest }) => (
     <div

--- a/component-lib/src/atoms/TelephoneNumberLink/TelephoneNumberLink.jsx
+++ b/component-lib/src/atoms/TelephoneNumberLink/TelephoneNumberLink.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Links
  */
 const TelephoneNumberLink = ({ children, className, ...rest }) => (
     <a

--- a/component-lib/src/atoms/TextArea/TextArea.jsx
+++ b/component-lib/src/atoms/TextArea/TextArea.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: FormElements
  */
 const TextArea = ({ children, className, error, ...rest }) => (
     <textarea

--- a/component-lib/src/atoms/TextBox/TextBox.jsx
+++ b/component-lib/src/atoms/TextBox/TextBox.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*.
+ * Category: FormElements
  *
  * Be sure to set the correct type when using this component as it helps the user to give correct input.
 **/

--- a/component-lib/src/atoms/ToggleButton/ToggleButton.jsx
+++ b/component-lib/src/atoms/ToggleButton/ToggleButton.jsx
@@ -4,6 +4,7 @@ import cn from 'classnames';
 
 /**
  * Status: *in progress*.
+ * Category: FormElements
  *
  * Work remaining: test in more browsers; use rem instead of px in the CSS.
  *

--- a/component-lib/src/atoms/ToggleSwitch/ToggleSwitch.jsx
+++ b/component-lib/src/atoms/ToggleSwitch/ToggleSwitch.jsx
@@ -9,6 +9,7 @@ const PANEL = {
 
 /**
  * Status: *In progress*.
+ * Category: FormElements
  */
 const ToggleSwitch = ({ leftLabel, rightLabel, leftOnClickHandler, rightOnClickHandler, active, backgroundColor, className }) => (
     <div

--- a/component-lib/src/atoms/UniqueSellingPoints/UniqueSellingPoints.jsx
+++ b/component-lib/src/atoms/UniqueSellingPoints/UniqueSellingPoints.jsx
@@ -6,6 +6,7 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *finished*
+ * Category: Lists
  */
 const UniqueSellingPoints = ({ children, iconName, iconColor, className, ...rest }) => (
     <ul

--- a/component-lib/src/molecules/Accordion/Accordion.jsx
+++ b/component-lib/src/molecules/Accordion/Accordion.jsx
@@ -5,7 +5,12 @@ import Button from '../../atoms/Button/Button';
 
 import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
-/**Status: Add possibility for passing objects to the right content area */
+/**
+ * Status: *Finished*
+ * Category: Accordion
+ *
+ * Add possibility for passing objects to the right content area
+*/
 
 export default class Accordion extends React.Component {
     static propTypes = {

--- a/component-lib/src/molecules/AccordionList/AccordionList.jsx
+++ b/component-lib/src/molecules/AccordionList/AccordionList.jsx
@@ -7,6 +7,7 @@ const noop = () => {};
 
 /**
  * Status: *finished*.
+ * Category: Accordion
  *
  * An AccordionList is a list of Accordions. An Accordion consists of a header and a panel.
  * The header contains a button which toggles the associated panel's visibility.

--- a/component-lib/src/molecules/Alert/Alert.jsx
+++ b/component-lib/src/molecules/Alert/Alert.jsx
@@ -7,6 +7,7 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *finished*.
+ * Category: Notifications
  */
 const Alert = ({
     kind = 'positive',

--- a/component-lib/src/molecules/ArticleList/ArticleList.jsx
+++ b/component-lib/src/molecules/ArticleList/ArticleList.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import Tags from '../../atoms/Tags/Tags';
 
+/**
+ * Status: *in progress*.
+ * Category: Lists
+ *
+ * TODO: Rename to search result
+ */
 const ArticleListItem = ({ article }) => (
     <li className="article-list__item">
         <a className="link article-list__title" href={article.link}>{article.title}</a>

--- a/component-lib/src/molecules/ArticleMetaData/ArticleMetaData.jsx
+++ b/component-lib/src/molecules/ArticleMetaData/ArticleMetaData.jsx
@@ -6,6 +6,7 @@ import uniqueId from 'lodash/uniqueId';
 
 /**
  * Status: *finished*
+ * Category: PageHeaders
  */
 const ArticleMetaData = ({ iconName, tags = [], date, author, className, ...rest }) => (
     <section

--- a/component-lib/src/molecules/Banner/Banner.jsx
+++ b/component-lib/src/molecules/Banner/Banner.jsx
@@ -4,9 +4,10 @@ import PropTypes from 'prop-types';
 
 /**
  * Status: *finished*.
+ * Category: Misc
  *
  * Should be placed in a medium or large container. Never small.
- * Should always use white banner on grey background and grey banner on white background. 
+ * Should always use white banner on grey background and grey banner on white background.
  **/
 export default class Banner extends React.Component {
     static propTypes = {

--- a/component-lib/src/molecules/BoxGrid/BoxGrid.jsx
+++ b/component-lib/src/molecules/BoxGrid/BoxGrid.jsx
@@ -3,14 +3,15 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*.
+ * Category: Boxes
  *
  * A BoxGrid component is a flexible container for the <a href="/components/atoms#Box">Box</a>
  * component. Take a look at the examples below and resize the browser to see the flow of the boxes.
  *
  * Flex in the boxes can be turned off with box--no-flex.
- * 
+ *
  * Content in boxes can be centered with box-grid--center-content.
- * 
+ *
  * You can override boxes to take up 45% of total width by using box--half-width.
  */
 const BoxGrid = ({ children, className, ...rest }) => (

--- a/component-lib/src/molecules/Campaign/Campaign.jsx
+++ b/component-lib/src/molecules/Campaign/Campaign.jsx
@@ -7,6 +7,7 @@ import Heading from '../../atoms/Heading/Heading';
 
 /**
  * Status: *almost finished*.
+ * Category: Hero
  *
  * This component is going to be used for campaigns, such as Music Freedom.
  *

--- a/component-lib/src/molecules/ChartLegend/ChartLegend.jsx
+++ b/component-lib/src/molecules/ChartLegend/ChartLegend.jsx
@@ -9,7 +9,10 @@ const getLegendClassName = (series, index) =>
             'chart-legend--right-border': index === 0 && series.length > 2,
             'chart-legend--left-border': index === series.length - 1 && series.length > 1
         });
-
+/**
+ * Status: *finished*.
+ * Category: Graphs
+ */
 const ChartLegend = ({ series }) => (
     <div className="chart-legend__container">
         {series.map((serie, i) =>

--- a/component-lib/src/molecules/CheckBoxWithLabel/CheckBoxWithLabel.jsx
+++ b/component-lib/src/molecules/CheckBoxWithLabel/CheckBoxWithLabel.jsx
@@ -5,6 +5,7 @@ import Label from '../../atoms/Label/Label';
 
 /**
  * Status: *in progress*.
+ * Category: FormElements
  *
  * Waiting on the Photoshop files to get the exact checkmark SVG.
  */

--- a/component-lib/src/molecules/DataBoostChart/DataBoostChart.jsx
+++ b/component-lib/src/molecules/DataBoostChart/DataBoostChart.jsx
@@ -4,6 +4,10 @@ import classNames from 'classnames';
 import ChartWrapper from '../DonutChart/ChartWrapper';
 import Spinner from '../../atoms/Spinner/Spinner';
 
+/**
+ * Status: *finished*.
+ * Category: Graphs
+ */
 const DataBoostChart = ({
     loading,
     size,

--- a/component-lib/src/molecules/DisplayFunctionality/DisplayFunctionality.jsx
+++ b/component-lib/src/molecules/DisplayFunctionality/DisplayFunctionality.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 /**
  * Status: *finished*
+ * Category: Misc
  */
 class DisplayFunctionality extends React.Component {
     constructor() {

--- a/component-lib/src/molecules/DonutChart/DonutChart.jsx
+++ b/component-lib/src/molecules/DonutChart/DonutChart.jsx
@@ -21,7 +21,10 @@ const alignSegments = (segments) =>
             color: segment.color
         }))
         .sort((seg1, seg2) => seg2.percent - seg1.percent);
-
+/**
+ * Status: *finished*.
+ * Category: Graphs
+ */
 const DonutChart = ({
     loading,
     size,

--- a/component-lib/src/molecules/DownloadButtons/DownloadButtons.jsx
+++ b/component-lib/src/molecules/DownloadButtons/DownloadButtons.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Buttons
  */
 const DownloadButtons = ({ children, className, ...rest }) => (
     <div

--- a/component-lib/src/molecules/DropDownListWithLabel/DropDownListWithLabel.jsx
+++ b/component-lib/src/molecules/DropDownListWithLabel/DropDownListWithLabel.jsx
@@ -9,8 +9,10 @@ const normalizeOptions = (options) =>
         ? option
         : { name: option, value: option });
 /**
- * Status: *finished*.
+ * Status: *In progress*.
+ * Category: FormElements
  *
+ * Improvements: Move to a generic dropdown component
  **/
 const DropDownListWithLabel = ({ className, labelMode, visibleLabel, label, selectedOption, changeSelectedOption, options = [], ...rest }) => (
     <Label

--- a/component-lib/src/molecules/FactBox/FactBox.jsx
+++ b/component-lib/src/molecules/FactBox/FactBox.jsx
@@ -34,7 +34,8 @@ const FactContent = ({ children, iconName, title, underline }) => (
 );
 
 /**
- * Status: *finished*
+ * Status: *finished*'
+ * Category: Boxes
  *
  * FactBox takes the width of its container, but we recommend to use it within a
  * <code>&lt;div class="container container--small"&gt;</code> as the example beneath shows.

--- a/component-lib/src/molecules/FocusBox/FocusBox.jsx
+++ b/component-lib/src/molecules/FocusBox/FocusBox.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *in progress*.
+ * Category: FocusBox
  *
  * Future work: change the pebble-type in the border, and animate it.
  *

--- a/component-lib/src/molecules/FocusSpinner/FocusSpinner.jsx
+++ b/component-lib/src/molecules/FocusSpinner/FocusSpinner.jsx
@@ -6,6 +6,7 @@ import Spinner from '../../atoms/Spinner/Spinner';
 
 /**
  * Status: *finished*.
+ * Category: FocusBox
  *
  * Like a FocusBox, but shown before the content is loaded.
  */

--- a/component-lib/src/molecules/FullWidthImage/FullWidthImage.jsx
+++ b/component-lib/src/molecules/FullWidthImage/FullWidthImage.jsx
@@ -7,6 +7,7 @@ import uniqueId from 'lodash/uniqueId';
 
 /**
  * Status: *finished*
+ * Category: ImageAndVideo
  *
  * Recommendations from designers:
  * - Images in the size of 1440x440px or the same width/height format seems to be a good size to use in this component.

--- a/component-lib/src/molecules/FunkyTabs/FunkyTabs.jsx
+++ b/component-lib/src/molecules/FunkyTabs/FunkyTabs.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 /**
  * Status: *finished*
+ * Category: Tabs
  *
  * <p>
  * The FunkyTabs component are implemented as a list, where each tab is a list element with a link inside.

--- a/component-lib/src/molecules/HardwareProduct/HardwareProduct.jsx
+++ b/component-lib/src/molecules/HardwareProduct/HardwareProduct.jsx
@@ -4,6 +4,10 @@ import classNames from 'classnames';
 
 import Heading from '../../atoms/Heading/Heading';
 
+/**
+ * Status: *Finished*.
+ * Category: Hardware
+ */
 const HardwareProduct = ({ className, campaign, url, onClick, image, name, priceDescription, price, priceDisclaimerLine1, priceDisclaimerLine2, ...rest }) =>
     <a className={classNames('hardware-product', className)} href={url} onClick={onClick} {...rest}>
         <div className="hardware-product__upper-container">

--- a/component-lib/src/molecules/Header/Header.jsx
+++ b/component-lib/src/molecules/Header/Header.jsx
@@ -7,6 +7,7 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *finished*.
+ * Category: PageHeaders
  */
 const Header = ({
     videoSrc,

--- a/component-lib/src/molecules/HeaderWithImage/HeaderWithImage.jsx
+++ b/component-lib/src/molecules/HeaderWithImage/HeaderWithImage.jsx
@@ -6,6 +6,7 @@ import Heading from '../../atoms/Heading/Heading';
 
 /**
  * Status: *finished*.
+ * Category: PageHeaders
  */
 const HeaderWithImage = ({ imgSrcMobile, imgSrcDesktop, blackText, whiteText, withGradient, pageTitle, children }) =>
     <header className={classNames('header header--plain header-with-image', { 'header--black-text': blackText, 'header--white-text': whiteText, 'header-with-image--with-gradient': withGradient })}>

--- a/component-lib/src/molecules/HeadingLink/HeadingLink.jsx
+++ b/component-lib/src/molecules/HeadingLink/HeadingLink.jsx
@@ -5,6 +5,7 @@ import HorizontalRule from '../../atoms/HorizontalRule/HorizontalRule';
 
 /**
  * Status: *in progress*
+ * Category: Links
  */
 const HeadingLink = ({ children, className, ...rest }) => (
     <a

--- a/component-lib/src/molecules/Hero/Hero.jsx
+++ b/component-lib/src/molecules/Hero/Hero.jsx
@@ -6,6 +6,7 @@ import uniqueId from 'lodash/uniqueId';
 
 /**
  * Status: *finished*
+ * Category: Hero
  *
  * The hero component requires two images, one for desktop and one for mobile view.
  * With using the <code>&lt;picture&gt;</code> element this component itself decides when to load and render

--- a/component-lib/src/molecules/Image/Image.jsx
+++ b/component-lib/src/molecules/Image/Image.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: ImageAndVideo
  */
 const Image = ({ children, className, src, alt, inline, ...rest }) => (
     <figure

--- a/component-lib/src/molecules/ImageHeadingLink/ImageHeadingLink.jsx
+++ b/component-lib/src/molecules/ImageHeadingLink/ImageHeadingLink.jsx
@@ -6,6 +6,7 @@ import HorizontalRule from '../../atoms/HorizontalRule/HorizontalRule';
 
 /**
  * Status: *in progress*
+ * Category: ImageAndVideo
  */
 const ImageHeadingLink = ({ children, className, src, alt, ...rest }) => (
     <a

--- a/component-lib/src/molecules/InfoBox/InfoBox.jsx
+++ b/component-lib/src/molecules/InfoBox/InfoBox.jsx
@@ -4,7 +4,8 @@ import Heading from '../../atoms/Heading/Heading';
 
 /**
  * Status: *finished*.
- * 
+ * Category: Boxes
+ *
  * This should be used in `small` or `medium` width containers. In a `large`, the text lines become too long to read comfortably.
  */
 const InfoBox = ({ title, children }) => (

--- a/component-lib/src/molecules/LightAlert/LightAlert.jsx
+++ b/component-lib/src/molecules/LightAlert/LightAlert.jsx
@@ -6,6 +6,7 @@ import Heading from '../../atoms/Heading/Heading';
 
 /**
  * Status: *in progress*.
+ * Category: Notifications
  */
 const LightAlert = ({
     title,

--- a/component-lib/src/molecules/ListWithImage/ListWithImage.jsx
+++ b/component-lib/src/molecules/ListWithImage/ListWithImage.jsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *finished*
+ * Category: Lists
  */
 const ListWithImage = ({ children, className, heading, src, alt, imagePosition = 'bottom', listPosition = 'left', hideImageForMobile, ...rest }) => (
     <div

--- a/component-lib/src/molecules/Menu/Menu.jsx
+++ b/component-lib/src/molecules/Menu/Menu.jsx
@@ -21,6 +21,7 @@ const isDescendant = (parent, child) => {
 
 /**
  * Status: *In progress*.
+ * Category: PageElements
  **/
 export default class Menu extends React.Component {
     static propTypes = {

--- a/component-lib/src/molecules/MiniDashboard/MiniDashboard.jsx
+++ b/component-lib/src/molecules/MiniDashboard/MiniDashboard.jsx
@@ -6,6 +6,7 @@ import map  from 'lodash/map';
 
 /**
  * Status: *in progress*.
+ * Category: Graphs
  *
  * A small dashboard to be placed on top of a page for the logged in user to view a snapshot
  * of Min Side info, and to be able to navigate quickly to the full Min Side page.

--- a/component-lib/src/molecules/ModalDialog/ModalDialog.jsx
+++ b/component-lib/src/molecules/ModalDialog/ModalDialog.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 /**
  * Status: *in progress*.
+ * Category: Notifications
  *
  * Look at the <a href='/modal-dialog'>Modal Dialog sample page</a> to see this component in action.
  *

--- a/component-lib/src/molecules/PageFooter/PageFooter.jsx
+++ b/component-lib/src/molecules/PageFooter/PageFooter.jsx
@@ -4,6 +4,7 @@ import map  from 'lodash/map';
 
 /**
  * Status: *finished*.
+ * Category: PageElements
  *
  * The PageFooter is the main footer on the page, and should be included only once.
  * It contains a small number of important, side-wide links.

--- a/component-lib/src/molecules/PageHeader/PageHeader.jsx
+++ b/component-lib/src/molecules/PageHeader/PageHeader.jsx
@@ -8,6 +8,7 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *in progress*.
+ * Category: PageElements
  *
  * Work remaining: menu, toolbar, responsiveness.
  *

--- a/component-lib/src/molecules/PageMenu/PageMenu.jsx
+++ b/component-lib/src/molecules/PageMenu/PageMenu.jsx
@@ -8,6 +8,13 @@ import MenuTopPanel from './MenuTopPanel';
 import MenuBar from './MenuBar';
 import Tabs from '../../molecules/Tabs/Tabs';
 
+
+/**
+ * Status: *Deprecated*
+ * Category: PageElements
+ *
+ * This component will be replaces with the Menu-component
+ */
 const PageMenu = ({
     menuLinks = [],
     menuId,

--- a/component-lib/src/molecules/PersonBox/PersonBox.jsx
+++ b/component-lib/src/molecules/PersonBox/PersonBox.jsx
@@ -6,6 +6,7 @@ import IconLink from '../../atoms/IconLink/IconLink';
 
 /**
  * Status: *finished*.
+ * Category: Boxes
  *
  * A PersonBox component use the default <a href="/components/atoms#Box">Box</a> component.
  * The content within this Box presents a person with an image, name, job title, description and

--- a/component-lib/src/molecules/PopUpLine/PopUpLine.jsx
+++ b/component-lib/src/molecules/PopUpLine/PopUpLine.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
-* Status: *in progress*.
+ * Status: *in progress*.
+ * Category: Notifications
  *
  * TODO:
  ** Add a dynamic example to the ModalDialogSamplePage; show information pop-up line after confirmed is clicked in a confirm modal dialog.

--- a/component-lib/src/molecules/PriceTable/PriceTable.jsx
+++ b/component-lib/src/molecules/PriceTable/PriceTable.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+/**
+ * Status: *finished*.
+ * Category: Tables
+ */
 const PriceTable = ({ productListWithPrice, totalTextWithPrice, additionalLine }) =>
     <table className="price-table">
         <tbody className="price-table__items">

--- a/component-lib/src/molecules/ProductList/ProductList.jsx
+++ b/component-lib/src/molecules/ProductList/ProductList.jsx
@@ -5,6 +5,7 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *finished*.
+ * Category: Lists
  *
  * Used for showing lists of products like subscriptions and services, in a less "in your face" manner than the Subscription component.
  */

--- a/component-lib/src/molecules/ProductPromoBox/ProductPromoBox.jsx
+++ b/component-lib/src/molecules/ProductPromoBox/ProductPromoBox.jsx
@@ -7,6 +7,7 @@ import Heading from '../../atoms/Heading/Heading';
 
 /**
  * Status: *finished*.
+ * Category: Hardware
  *
  * A ProductPromoBox component use the default <a href="/components/atoms#Box">Box</a> component.
  * The content within this box presents a product with a name, image, price and short description.

--- a/component-lib/src/molecules/ProgressChart/ProgressChart.jsx
+++ b/component-lib/src/molecules/ProgressChart/ProgressChart.jsx
@@ -12,6 +12,7 @@ const getThresholdFromValue = (thresholds, value) =>
 
 /**
  * Status: *in progress*.
+ * Category: Graphs
  *
  * Future work: Finetune the default thresholds.
  *

--- a/component-lib/src/molecules/PromoBox/PromoBox.jsx
+++ b/component-lib/src/molecules/PromoBox/PromoBox.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *in progress*.
+ * Category: Boxes
  *
  * The PromoBox is created to display a promoted feature.
  * It can be animated by adding class name promo-box__animated

--- a/component-lib/src/molecules/RadioButtonList/RadioButtonList.jsx
+++ b/component-lib/src/molecules/RadioButtonList/RadioButtonList.jsx
@@ -9,7 +9,7 @@ const getClassName = (type, hasRichContent) =>
 
 /**
  * Status: *finished*.
- *
+ * Category: FormElements
  */
 const RadioButtonList = ({ list = [], selectedIndex, name, type, hasRichContent, onChange, children }) =>
     <div className={getClassName(type, hasRichContent)}>

--- a/component-lib/src/molecules/RecommendedProducts/RecommendedProducts.jsx
+++ b/component-lib/src/molecules/RecommendedProducts/RecommendedProducts.jsx
@@ -4,6 +4,10 @@ import PropTypes from 'prop-types';
 import Heading from '../../atoms/Heading/Heading';
 import Button from '../../atoms/Button/Button';
 
+/**
+ * Status: *Finished*.
+ * Category: Hardware
+ */
 const RecommendedProducts = ({ mainHeading, products = [], image, heading, text, buttonText }) =>
     <div className="recommended-products">
         <Heading level="2" text={mainHeading} className="recommended-products__heading" />

--- a/component-lib/src/molecules/References/References.jsx
+++ b/component-lib/src/molecules/References/References.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+/**
+ * Status: *delete from styleguide*.
+ * Category: Lists
+ */
 const References = ({ items = [], heading }) => (
     <section className="references container container--no-margin container--no-padding">
         <h2 className="heading heading--level-2 heading--pebble references__heading">{heading}</h2>

--- a/component-lib/src/molecules/RelatedArticle/RelatedArticle.jsx
+++ b/component-lib/src/molecules/RelatedArticle/RelatedArticle.jsx
@@ -5,6 +5,7 @@ import Tags from '../../atoms/Tags/Tags';
 
 /**
  * Status: *finished*
+ * Category: Misc
  */
 const RelatedArticle = ({ children, className, imgSrc, imgAlt, heading, tags = [], ...rest }) => (
     <a className={classnames('related-article', { [className]: className })}

--- a/component-lib/src/molecules/RelatedArticles/RelatedArticles.jsx
+++ b/component-lib/src/molecules/RelatedArticles/RelatedArticles.jsx
@@ -7,6 +7,7 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *finished*.
+ * Category: Misc
  */
 export default class RelatedArticles extends React.Component {
     static propTypes = {

--- a/component-lib/src/molecules/RichText/RichText.jsx
+++ b/component-lib/src/molecules/RichText/RichText.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 
 /**
  * Status: *in progress*.
+ * Category: Style
  *
  * This is a component that is meant to be used as a container for text (headings, paragraphs etc.)
  * to give the text a certain layout with spacing between elements.

--- a/component-lib/src/molecules/StatsDisplay/StatsDisplay.jsx
+++ b/component-lib/src/molecules/StatsDisplay/StatsDisplay.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 /**
- * 
+ *
  * Status: *Finished*.
+ * Category: Graphs
  *
  * A component for displaying simple facts and statistics that can have either a small header (numbers in this case) or an icon.
  **/

--- a/component-lib/src/molecules/StepByStep/StepByStep.jsx
+++ b/component-lib/src/molecules/StepByStep/StepByStep.jsx
@@ -6,6 +6,7 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *finished*
+ * Category: Wizard
  */
 class StepByStep extends React.Component {
     static propTypes = {

--- a/component-lib/src/molecules/Subscription/Subscription.jsx
+++ b/component-lib/src/molecules/Subscription/Subscription.jsx
@@ -12,6 +12,7 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *finished*.
+ * Category: Subscription
  *
  */
 const Subscription = ({ isShowingFeatures, isStandalone, isBroadband, color, size, id, isExpanded, name, dataAmount, dataUnit, price, speechBubbleText,

--- a/component-lib/src/molecules/Tabs/Tabs.jsx
+++ b/component-lib/src/molecules/Tabs/Tabs.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
+/**
+ * Status: *finished*
+ * Category: Tabs
+ */
 const Tabs = ({ uniqueId, children, selectedIndex, onSelect, skipPanelRendering, noMargin, compact }) =>
     <div className={classnames(
         'tabs',

--- a/component-lib/src/molecules/TextAreaWithLabel/TextAreaWithLabel.jsx
+++ b/component-lib/src/molecules/TextAreaWithLabel/TextAreaWithLabel.jsx
@@ -6,6 +6,7 @@ import Label from '../../atoms/Label/Label';
 
 /**
  * Status: *finished*.
+ * Category: FormElements
  **/
 const TextAreaWithLabel = ({ labelText, placeholder, error, disabled, ...rest }) =>
     <Label className="textarea-with-label" isUsingGrayText={true}>

--- a/component-lib/src/molecules/TextBoxWithIcon/TextBoxWithIcon.jsx
+++ b/component-lib/src/molecules/TextBoxWithIcon/TextBoxWithIcon.jsx
@@ -25,6 +25,7 @@ const TextBoxIcon = ({ iconName, iconIsButton, iconColor, iconLabel }) => {
 
 /**
  * Status: *finished*.
+ * Category: FormElements
 **/
 const TextBoxWithIcon = React.forwardRef(({ className, type, placeholder, disabled, error, small, iconName, iconColor, iconIsButton, iconLabel, ...rest }, ref) => (
     <div

--- a/component-lib/src/molecules/TextBoxWithLabel/TextBoxWithLabel.jsx
+++ b/component-lib/src/molecules/TextBoxWithLabel/TextBoxWithLabel.jsx
@@ -8,6 +8,7 @@ import TextBoxWithIcon from '../TextBoxWithIcon/TextBoxWithIcon';
 
 /**
  * Status: *in progress*.
+ * Category: FormElements
 **/
 const TextBoxWithLabel = React.forwardRef(({ labelText, type, placeholder, errorMessage, disabled, withIcon, iconName, iconColor, iconIsButton, ...rest }, ref) => (
     <Label className={classnames('textbox-with-label', { 'textbox-with-label--with-error': errorMessage })} isUsingGrayText={true}>

--- a/component-lib/src/molecules/Tooltip/Tooltip.jsx
+++ b/component-lib/src/molecules/Tooltip/Tooltip.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 /**
+ * Status: *finished*
+ * Category: FormElements
+ *
  * This tooltip is implemented with the purpose of having to open/close it by clicking or using keyboard,
  * but the behavior is not implemented as a part of the styleguide.
  **/

--- a/component-lib/src/molecules/Video/Video.jsx
+++ b/component-lib/src/molecules/Video/Video.jsx
@@ -5,6 +5,7 @@ import SvgIcon from '../../atoms/SvgIcon';
 
 /**
  * Status: *finished*
+ * Category: ImageAndVideo
  */
 const Video = ({ className, src, allowFullScreen, img, description, autoplay, ...rest }) => (
     <div
@@ -14,7 +15,7 @@ const Video = ({ className, src, allowFullScreen, img, description, autoplay, ..
         })}
         {...rest}>
         <div className="video__iframe-wrapper">
-            {img && !autoplay && 
+            {img && !autoplay &&
                 <div className="video__custom_details">
                     <img src={img} alt="" className="video__thumbnail" />
                     <div className="video__details">
@@ -28,7 +29,7 @@ const Video = ({ className, src, allowFullScreen, img, description, autoplay, ..
                 className="video__iframe"
                 allowFullScreen={allowFullScreen} />
         </div>
-        {!img && 
+        {!img &&
             <div className="caption">{description}</div>
         }
     </div>

--- a/component-lib/src/organisms/ContentRating/ContentRating.jsx
+++ b/component-lib/src/organisms/ContentRating/ContentRating.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
+/**
+ * Status: *delete from styleguide*
+ * Category: FormElements
+ */
 export default class ContentRating extends React.Component {
     static propTypes = {
         feedbackState: PropTypes.oneOf(['initial', 'receipt-positive', 'negative-feedback', 'receipt-negative']),

--- a/component-lib/src/organisms/FeatureBoxes/FeatureBox.jsx
+++ b/component-lib/src/organisms/FeatureBoxes/FeatureBox.jsx
@@ -3,6 +3,10 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Paragraph from '../../atoms/Paragraph/Paragraph';
 
+/**
+ * Status: *finished*.
+ * Category: Boxes
+**/
 export default class FeatureBox extends React.Component {
     static propTypes = {
         iconSvg: PropTypes.node,

--- a/component-lib/src/organisms/FeatureBoxes/FeatureBoxes.jsx
+++ b/component-lib/src/organisms/FeatureBoxes/FeatureBoxes.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 /**
  * Status: *finished*.
+ * Category: Boxes
  *
  * There should be a minimum of three- and a maximum of eight boxes when using this component.
  **/

--- a/component-lib/src/organisms/FocusBoxWithLabels/FocusBoxWithLabels.jsx
+++ b/component-lib/src/organisms/FocusBoxWithLabels/FocusBoxWithLabels.jsx
@@ -3,6 +3,12 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import FocusBox from '../../molecules/FocusBox/FocusBox';
 
+/**
+ * Status: *should be deleted*.
+ * Category: FocusBox
+ *
+ * TODO: better documentation.
+ */
 const FocusBoxWithLabels = ({ padding, content: { upperLeft, upperRight, bottomLeft, bottomRight } }) => {
     return (
         <FocusBox className="focus-box-with-labels">

--- a/component-lib/src/organisms/FocusSubscription/FocusSubscription.jsx
+++ b/component-lib/src/organisms/FocusSubscription/FocusSubscription.jsx
@@ -5,7 +5,8 @@ import FocusBox from '../../molecules/FocusBox/FocusBox';
 import Subscription from '../../molecules/Subscription/Subscription';
 
 /**
- * Status: *finished*.
+ * Status: *should be deleted*.
+ * Category: FocusBox
  *
  */
 export default class FocusSubscription extends React.Component {

--- a/component-lib/src/organisms/Form/Form.jsx
+++ b/component-lib/src/organisms/Form/Form.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 
 /**
+ * Category: FormElements
  *
  * The layout of a form is created by nesting `form__row` and `form__column`.
  * Inside each column you add the components you need for creating your own form.

--- a/component-lib/src/organisms/HardwareProductList/HardwareProductList.jsx
+++ b/component-lib/src/organisms/HardwareProductList/HardwareProductList.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+/**
+ * Status: *Finished*.
+ * Category: Hardware
+ */
 const HardwareProductList = ({ children }) =>
     <div className="hardware-product-list">
         {children}

--- a/component-lib/src/organisms/ProductListGrid/ProductListGrid.jsx
+++ b/component-lib/src/organisms/ProductListGrid/ProductListGrid.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import classnames from 'classnames';
 
+/**
+ * Status: *Finished*
+ * Category: Misc
+*/
 const ProductListGrid = ({ children, layout }) =>
     <div className={classnames('product-list-grid', { 'product-list-grid--horizontal': (layout === 'horizontal') })}>
         {children}

--- a/component-lib/src/organisms/ThemeBoxWithImage/ThemeBoxWithImage.jsx
+++ b/component-lib/src/organisms/ThemeBoxWithImage/ThemeBoxWithImage.jsx
@@ -5,8 +5,9 @@ import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
 /**
  * Status: *in progress*
+ * Category: Accordion
  *
- * Box to display a theme with a header image. 
+ * Box to display a theme with a header image.
  **/
 export default class ThemeBoxWithImage extends React.Component{
     static propTypes = {

--- a/component-lib/src/organisms/ThemeBoxes/ThemeBox.jsx
+++ b/component-lib/src/organisms/ThemeBoxes/ThemeBox.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SvgIcon from '../../atoms/SvgIcon/SvgIcon';
 
+/**
+ * Status: *Finished*
+ * Category: Accordion
+*/
 export default class ThemeBox extends React.Component {
     static propTypes = {
         isExpanded: PropTypes.bool,

--- a/component-lib/src/organisms/ThemeBoxes/ThemeBoxes.jsx
+++ b/component-lib/src/organisms/ThemeBoxes/ThemeBoxes.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 /**
  * Status: *in progress*
+ * Category: Accordion
  *
  * There should be a minimum of two- and a maximum of six boxes when using this component.
  **/

--- a/src/component-categories.js
+++ b/src/component-categories.js
@@ -1,0 +1,24 @@
+const categories = [
+    { key: 'accordion', name: 'Accordions' },
+    { key: 'boxes', name: 'Boxes' },
+    { key: 'buttons', name: 'Buttons' },
+    { key: 'focusbox', name: 'Focus box' },
+    { key: 'formElements', name: 'Form elements' },
+    { key: 'graphs', name: 'Graphs' },
+    { key: 'hardware', name: 'Hardware' },
+    { key: 'hero', name: 'Hero' },
+    { key: 'imageandvideo', name: 'Image & video' },
+    { key: 'links', name: 'Links' },
+    { key: 'lists', name: 'Lists' },
+    { key: 'loader', name: 'Loaders' },
+    { key: 'notifications', name: 'Notifications' },
+    { key: 'pageElements', name: 'Page Elements' },
+    { key: 'pageHeaders', name: 'Page headers' },
+    { key: 'style', name: 'Page style' },
+    { key: 'subscription', name: 'Subscription' },
+    { key: 'tables', name: 'Tables' },
+    { key: 'tabs', name: 'Tabs' },
+    { key: 'wizard', name: 'Steps & wizard' }
+];
+
+export default categories;

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -7,10 +7,13 @@ import AllIcons from 'component-lib-root/assets/allicons/AllIcons.js';
 import HomePage from './pages/HomePage';
 import LayoutPage from './pages/LayoutPage';
 import ComponentsPage from './pages/ComponentsPage';
+import ComponentsAtomicPage from './pages/ComponentsAtomicPage';
 import ComponentsByTypePage from './pages/ComponentsByTypePage';
+import ComponentsByCategoryPage from './pages/ComponentsByCategoryPage';
 import ContributingPage from './pages/ContributingPage';
 import DownloadPage from './pages/DownloadPage';
 import ImageAssetsPage from './pages/ImageAssetsPage';
+import StylePage from './pages/StylePage';
 import VersionsPage from './pages/VersionsPage';
 
 import InformationArticleSample1 from './pages/InformationArticleSample1';
@@ -42,9 +45,8 @@ const menuLinks = [
     {
         heading: { text: 'Component Library', url: '/components' },
         links: [
-            { text: 'Atoms', url: '/components/atoms' },
-            { text: 'Molecules', url: '/components/molecules' },
-            { text: 'Organisms', url: '/components/organisms' },
+            { text: 'Components', url: '/components/' },
+            { text: 'Components in atomic structure', url: '/components-atomic/' },
         ]
     }
 ];
@@ -69,7 +71,9 @@ const Routes = () => {
             <Route exact path="/" component={HomePage} />
             <Route exact path="/layout" component={LayoutPage} />
             <Route exact path="/components" component={ComponentsPage} />
-            <Route exact path="/components/:componentType" component={ComponentsByTypePage} />
+            <Route exact path="/components-atomic" component={ComponentsAtomicPage} />
+            <Route exact path="/components-atomic/:componentType" component={ComponentsByTypePage} />
+            <Route exact path="/components/:componentCategory" component={ComponentsByCategoryPage} />
             <Route exact path="/image-assets" component={ImageAssetsPage} />
             <Route exact path="/contributing" component={ContributingPage} />
             <Route exact path="/download" component={DownloadPage} />
@@ -88,6 +92,7 @@ const Routes = () => {
             <Route exact path="/forms" component={FormsSamplePage} />
             <Route exact path="/usage" component={UsagePage} />
             <Route exact path="/modal-dialog" component={ModalDialogSamplePage} />
+            <Route exact path="/style" component={StylePage} />
             <Route exact path="/tabs" component={TabsSamplePage} />
 
             <PageFooter

--- a/src/components/pages/ComponentsAtomicPage.jsx
+++ b/src/components/pages/ComponentsAtomicPage.jsx
@@ -1,0 +1,65 @@
+import _ from 'lodash';
+import React from 'react';
+
+import { Header } from 'component-lib';
+import { getComponents } from '../../utils/componentUtil';
+
+const ComponentList = ({ type, components }) => {
+    return (
+        <ul className="list list--links">
+            {_.map(components, (component) =>
+                <li className="list__item" key={component.name}>
+                    <a className="list__link" href={`/components-atomic/${type}#${component.name}`}>{component.name}</a>
+                </li>
+            )}
+        </ul>
+    );
+};
+
+const ComponentsAtomicPage = () => {
+    const allComponents = getComponents();
+
+    return (
+        <div>
+            <Header
+                iconName="ico_code-2"
+                pageTitle="Components"
+                withMask={false}
+                withContentOverlap={false}>
+                <div>
+                    Here are the <a className="link" href="http://bradfrost.com/blog/post/atomic-web-design/">Atomic Design</a> components, split by category.
+                </div>
+            </Header>
+            <div className="container container--small container--extra-margin-bottom">
+                <h2 className="heading heading--level-2"><a className="link" href="/components-atomic/atoms">Atoms</a></h2>
+                <ComponentList type="atoms" components={allComponents['atoms']} />
+
+                <h2 className="heading heading--level-2"><a className="link" href="/components-atomic/molecules">Molecules</a></h2>
+                <ComponentList type="molecules" components={allComponents['molecules']} />
+
+                <h2 className="heading heading--level-2"><a className="link" href="/components-atomic/organisms">Organisms</a></h2>
+                <ComponentList type="organisms" components={allComponents['organisms']} />
+
+                <h2 className="heading heading--level-2">Pages</h2>
+                <ul className="list list--links">
+                    <li className="list__item"><a className="list__link" href="/subscriptions">Subscription list page</a></li>
+                    <li className="list__item"><a className="list__link" href="/tabs">Tabs</a></li>
+                    <li className="list__item"><a className="list__link" href="/information-article-1">Information article 1</a> - basic components</li>
+                    <li className="list__item"><a className="list__link" href="/information-article-2">Information article 2</a></li>
+                    <li className="list__item"><a className="list__link" href="/information-article-3">Information article 3</a> - with StepByStep</li>
+                    <li className="list__item"><a className="list__link" href="/information-article-4">Information article 4</a> - with table</li>
+                    <li className="list__item"><a className="list__link" href="/information-article-5">Information article 5</a></li>
+                    <li className="list__item"><a className="list__link" href="/pebbles-page">Pebble page</a></li>
+                    <li className="list__item"><a className="list__link" href="/box-grid">Box Grid page</a></li>
+                    <li className="list__item"><a className="list__link" href="/blog-1">Blog page 1</a></li>
+                    <li className="list__item"><a className="list__link" href="/blog-2">Blog page 2</a></li>
+                    <li className="list__item"><a className="list__link" href="/forms">Forms</a></li>
+                    <li className="list__item"><a className="list__link" href="/usage">Usage page</a></li>
+                    <li className="list__item"><a className="list__link" href="/modal-dialog">Modal Dialog</a></li>
+                </ul>
+            </div>
+        </div>
+    );
+};
+
+export default ComponentsAtomicPage;

--- a/src/components/pages/ComponentsByCategoryPage.jsx
+++ b/src/components/pages/ComponentsByCategoryPage.jsx
@@ -1,0 +1,35 @@
+import _ from 'lodash';
+import React from 'react';
+
+import { Header } from 'component-lib';
+import ComponentDocs from '../common/ComponentDocs';
+import { getComponentsByCategory } from '../../utils/componentUtil';
+
+export default class ComponentsByCategoryPage extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+    render() {
+        const allComponents = getComponentsByCategory();
+        const { componentCategory } = this.props.match.params;
+        const categoryWithComponents = allComponents[componentCategory];
+
+        return (
+            <div>
+                <Header
+                    iconName="ico_code"
+                    pageTitle={`Components: ${categoryWithComponents.heading}`}
+                    withMask={false}
+                    withContentOverlap={false} />
+                { categoryWithComponents.components &&
+                    <div className="container container--no-padding container--extra-margin-bottom">
+                        {_.map(categoryWithComponents.components, (component, key) =>
+                            <ComponentDocs key={key} component={component} />
+                        )}
+                    </div>
+                }
+
+            </div>
+        );
+    }
+}

--- a/src/components/pages/ComponentsByTypePage.jsx
+++ b/src/components/pages/ComponentsByTypePage.jsx
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 
-import { Header } from '../../../component-lib/src/index';
+import { Header } from 'component-lib';
 import ComponentDocs from '../common/ComponentDocs';
 import { getComponents } from '../../utils/componentUtil';
 
@@ -13,7 +13,7 @@ export default class ComponentsByTypePage extends React.Component {
         const allComponents = getComponents();
         const { componentType } = this.props.match.params;
         const componentsOfType = allComponents[componentType];
-        
+
         return (
             <div>
                 <Header

--- a/src/components/pages/ComponentsPage.jsx
+++ b/src/components/pages/ComponentsPage.jsx
@@ -1,65 +1,38 @@
 import _ from 'lodash';
 import React from 'react';
 
-import { Header } from '../../../component-lib/src/index';
-import { getComponents } from '../../utils/componentUtil';
+import { Header, ProductList } from 'component-lib';
+import { getComponentsByCategory } from '../../utils/componentUtil';
 
-const ComponentList = ({ type, components }) => {
-    return (
-        <ul className="list list--links">
-            {_.map(components, (component) =>
-                <li className="list__item" key={component.name}>
-                    <a className="list__link" href={`/components/${type}#${component.name}`}>{component.name}</a>
-                </li>
-            )}
-        </ul>
-    );
+const CategoryList = ({ categories }) => {
+
+    const items = _.map(categories, (category, categoryName) => {
+        return {
+            iconName: '',
+            title: category.heading,
+            href: categoryName === 'style' ? '/style' : `/components/${categoryName}`,
+        };
+    });
+
+    return <ProductList items={items} />;
 };
 
-const ComponentsPage = () => {
-    const allComponents = getComponents();
+const categories = getComponentsByCategory();
 
-    return (
-        <div>
-            <Header
-                iconName="ico_code-2"
-                pageTitle="Components"
-                withMask={false}
-                withContentOverlap={false}>
-                <div>
-                    Here are the <a className="link" href="http://bradfrost.com/blog/post/atomic-web-design/">Atomic Design</a> components, split by category.
-                </div>
-            </Header>
-            <div className="container container--small container--extra-margin-bottom">
-                <h2 className="heading heading--level-2"><a className="link" href="/components/atoms">Atoms</a></h2>
-                <ComponentList type="atoms" components={allComponents['atoms']} />
-
-                <h2 className="heading heading--level-2"><a className="link" href="/components/molecules">Molecules</a></h2>
-                <ComponentList type="molecules" components={allComponents['molecules']} />
-
-                <h2 className="heading heading--level-2"><a className="link" href="/components/organisms">Organisms</a></h2>
-                <ComponentList type="organisms" components={allComponents['organisms']} />
-
-                <h2 className="heading heading--level-2">Pages</h2>
-                <ul className="list list--links">
-                    <li className="list__item"><a className="list__link" href="/subscriptions">Subscription list page</a></li>
-                    <li className="list__item"><a className="list__link" href="/tabs">Tabs</a></li>
-                    <li className="list__item"><a className="list__link" href="/information-article-1">Information article 1</a> - basic components</li>
-                    <li className="list__item"><a className="list__link" href="/information-article-2">Information article 2</a></li>
-                    <li className="list__item"><a className="list__link" href="/information-article-3">Information article 3</a> - with StepByStep</li>
-                    <li className="list__item"><a className="list__link" href="/information-article-4">Information article 4</a> - with table</li>
-                    <li className="list__item"><a className="list__link" href="/information-article-5">Information article 5</a></li>
-                    <li className="list__item"><a className="list__link" href="/pebbles-page">Pebble page</a></li>
-                    <li className="list__item"><a className="list__link" href="/box-grid">Box Grid page</a></li>
-                    <li className="list__item"><a className="list__link" href="/blog-1">Blog page 1</a></li>
-                    <li className="list__item"><a className="list__link" href="/blog-2">Blog page 2</a></li>
-                    <li className="list__item"><a className="list__link" href="/forms">Forms</a></li>
-                    <li className="list__item"><a className="list__link" href="/usage">Usage page</a></li>
-                    <li className="list__item"><a className="list__link" href="/modal-dialog">Modal Dialog</a></li>
-                </ul>
+const ComponentsPage = () =>
+    <div>
+        <Header
+            iconName="ico_code-2"
+            pageTitle="Components"
+            withMask={false}
+            withContentOverlap={false}>
+            <div>
+                Here are the components by category.
             </div>
+        </Header>
+        <div className="container container--small container--extra-margin-bottom">
+            <CategoryList categories={categories}></CategoryList>
         </div>
-    );
-};
+    </div>;
 
 export default ComponentsPage;

--- a/src/components/pages/StylePage.jsx
+++ b/src/components/pages/StylePage.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import _ from 'lodash';
+
+import { Header, Heading, RichText } from 'component-lib';
+
+import Color from '../common/Color';
+import ComponentDocs from '../common/ComponentDocs';
+
+import { getStaticData } from '../../utils/staticDataUtil';
+import { getComponentsByCategory } from '../../utils/componentUtil';
+
+
+const colors = getStaticData('colors');
+
+const styleComponents = getComponentsByCategory()['style'].components;
+
+const getComponentByName = (name) =>
+    styleComponents.filter(component => component.name === name)[0];
+
+/**
+ * Improvement: Redisign layout so that it is clearer what the sections
+ */
+const StylePage = () =>
+    <div>
+        <Header iconName="ico_code-2" pageTitle="Page style" />
+        <div className=" sg-component">
+            <div className="container container--medium container--extra-padding-top">
+                <Heading level={2} text="Colors" />
+                <p className="paragraph">
+                    The color palette below was taken from the
+                    <a href="https://brandhub.teliacompany.com/document/14#/colour-palette/our-colour-palette">
+                        Telia Company design document
+                    </a>
+                    and shows the recommended font color to give the correct contrast.
+                </p>
+                <div className="sg-colors-wrapper">
+                    {_.map(colors, (color, name) => <Color key={name} name={name} {...color} />)}
+                </div>
+            </div>
+        </div>
+
+        <div className="container container--medium container--extra-padding-top">
+            <Heading level={2} text="Icons" />
+        </div>
+        <ComponentDocs component={getComponentByName('SvgIcon')} />
+        <ComponentDocs component={getComponentByName('IconAnimated')} />
+
+        <div className="container container--medium">
+            <Heading level={2} text="Typography" />
+        </div>
+        <ComponentDocs component={getComponentByName('RichText')} />
+        <div className="container container--medium">
+            <Heading level={2} text="Heading" />
+            <ul>
+                <li><strong>Heading level one</strong> should be used once per page. And is the main heading of the page. Due to accessibility and readability this is the only heading that use the pebble font.</li>
+                <li>The content of a page is usually divided into sections, and <strong>heading level two</strong> should be used as the heading of these.</li>
+                <li><strong>Heading level three</strong> and <strong>heading level four</strong> is used when you need to divide content in even smaller sections.</li>
+            </ul>
+
+            <p className="paragraph">These are the heading levels defined in this styleguide: </p>
+            {_.map([1, 2, 3, 4], (level) =>
+                <Heading key={level} level={level} text={`h${level}. Heading level ${level}`} />
+            )}
+        </div>
+        <ComponentDocs component={getComponentByName('Paragraph')} />
+        <ComponentDocs component={getComponentByName('Quote')} />
+        <ComponentDocs component={getComponentByName('SpecialMessage')} />
+        <ComponentDocs component={getComponentByName('DescriptionList')} />
+    </div>;
+
+export default StylePage;

--- a/src/components/pages/SubscriptionSamplePage.jsx
+++ b/src/components/pages/SubscriptionSamplePage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FunkyTabs, Subscription } from '../../../component-lib/src/index';
+import { FunkyTabs, Subscription } from 'component-lib';
 
 const underFemtenSubscriptionProps = [
     {

--- a/src/utils/componentUtil.js
+++ b/src/utils/componentUtil.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
+import componentCategories from '../component-categories';
 
-import { getComponentDocumentation } from './staticDataUtil';
+import { getComponentDocumentation, getComponentCategory } from './staticDataUtil';
 
 function getComponentsByType(type, componentsInFolder) {
     const examples = require('../components/examples/**/*.js');
@@ -24,11 +25,64 @@ function getComponentsByType(type, componentsInFolder) {
     }, {});
 }
 
+function getComponentsByPredicate(predicate, allComponents, heading = '') {
+    const examples = require('../components/examples/**/*.js');
+
+    const componentsInCategory = _.map(allComponents, (components, type) => {
+        const filtered = _.filter(components, (_, componentName) => predicate(type, componentName));
+
+        return filtered.map(c =>
+            _.map(c, (component, name) => ({
+                name,
+                type,
+                component,
+                docs: getComponentDocumentation(type, name) || '*No documentation found*',
+                examples: examples[type][name]
+            }))
+        );
+    });
+
+    const flattenedCompontents = _.flattenDeep(componentsInCategory);
+    return {
+        heading: heading || category,
+        components: flattenedCompontents
+    };
+}
+
 export function getComponents() {
     return {
         atoms: getComponentsByType('atoms', require('../../component-lib/src/atoms/**/*.jsx')),
         molecules: getComponentsByType('molecules', require('../../component-lib/src/molecules/**/*.jsx')),
         organisms: getComponentsByType('organisms', require('../../component-lib/src/organisms/**/*.jsx'))
+    };
+}
+
+export function getComponentsByCategory() {
+    const allComponents = require('../../component-lib/src/**/**/*.jsx');
+
+    const matchesCategory = (type, componentName, category) =>
+        getComponentCategory(type, componentName).toLowerCase() === category.toLowerCase();
+
+    const matchesNoCategory = (type, componentName) =>
+        componentCategories.filter(category => matchesCategory(type, componentName, category.key)).length === 0;
+
+    const componentsByCategory = componentCategories
+        .reduce((result, category) => ({
+            ...result,
+            [category.key]: getComponentsByPredicate(
+                (type, componentName) => matchesCategory(type, componentName, category.key),
+                allComponents,
+                category.name)
+        }), {});
+
+    const uncategorizedComponents = getComponentsByPredicate(
+        matchesNoCategory,
+        allComponents,
+        'Without category');
+
+    return {
+        ...componentsByCategory,
+        misc: uncategorizedComponents,
     };
 }
 

--- a/src/utils/staticDataUtil.js
+++ b/src/utils/staticDataUtil.js
@@ -1,18 +1,38 @@
 const allData = require('../static-data.json');
 
-export function getStaticData(key) {    
+export function getStaticData(key) {
     return key ? allData[key] : allData;
 }
 
 const componentDocs = require('../component-docs.json');
 
-export function getComponentDocumentation(type, name) {    
-    // Keys are like: "component-lib/src/organisms/ThemeBoxes/ThemeBoxes.jsx"
-    const possibleKey = `component-lib/src/${type}/${name}/${name}.jsx`;
-    const match = componentDocs[possibleKey];
-    
+export function getComponentDocumentation(type, name) {
+    const match = findMatch(type, name);
     if (match && match.description) {
-        return match.description;
+        return match.description.replace( /Category:\s\w*/gi, '');
     }
     return '';
 }
+
+export function getComponentCategory(type, name) {
+    const match = findMatch(type, name);
+    if (match && match.description) {
+        const re = /Category:\s(?<category>\w*)/g;
+        const res = re.exec(match.description);
+        if (res) {
+            return res.groups.category;
+        }
+    }
+    return '';
+}
+
+const findMatch = (type, name) => {
+    // Keys are like: "component-lib/src/organisms/ThemeBoxes/ThemeBoxes.jsx"
+    let unixKey = `component-lib/src/${type}/${name}/${name}.jsx`;
+    let match = componentDocs[unixKey];
+    if (!match) {
+        const windowsKey = unixKey.replace(/\//gi, '\\');
+        match = componentDocs[windowsKey];
+    }
+    return match;
+};


### PR DESCRIPTION
**Goal of this task:** Make it simpler for new people to find components on the page by structuring them by functionality instead of atom/molecule/organism. 
The structure is copied from [this board](https://trello.com/b/wIufv7Mg/styleguide-regroup-and-rename).

Remaining tasks: 

- The page displaying style at `/style`  containing header, paragraph, icons, etc. has a unclear structure now with headings and separators. Please come with suggestions on how this page can look.
- The navigating/links for the component library is now a bit weird as the top level link goes to the same place as the cum-link "components". Any ideas on how we should link this?


**Also:** I have not deleted elements marked for deletion or renamed components as I think that should be done in a separate feature