### PR TITLE
npm install before npm run build

### DIFF
--- a/ci/tasks/build-website/task.yml
+++ b/ci/tasks/build-website/task.yml
@@ -22,5 +22,5 @@ run:
   - |
     mv cache/node_modules styleguide
     mv cache-component-lib/node_modules styleguide/component-lib
-    cd styleguide/component-lib && npm run build:css
-    cd .. && npm run build
+    cd styleguide/component-lib && npm install && npm run build:css
+    cd .. && npm install && npm run build

--- a/ci/tasks/update-and-publish-npm/task.sh
+++ b/ci/tasks/update-and-publish-npm/task.sh
@@ -22,6 +22,7 @@ echo "Update component lib version:"
 cd component-lib
 npm version ${update_type} --no-git-tag
 
+npm install
 npm run build
 
 export NPM_TOKEN=${npm_token}


### PR DESCRIPTION
not sure how the concourse pipeline tasks and cache work at all. But shouldn't it contain `npm install` somewhere before `npm run build` to handle the new dependencies?