### PR TITLE
updateing colors and svgicon color support

### DIFF
--- a/component-lib/src/atoms/SvgIcon/SvgIcon.jsx
+++ b/component-lib/src/atoms/SvgIcon/SvgIcon.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { colorNames } from '../../constants'
 
 /**
  * Status: *In progress*.
@@ -25,7 +26,7 @@ SvgIcon.propTypes = {
     /** The name of the icon*/
     iconName: PropTypes.string,
     /** The color of the icon (white, black, purple, grey or none)*/
-    color: PropTypes.oneOf(['white', 'black', 'purple', 'grey', 'light-grey', 'green', 'dark-grey', 'none']),
+    color: PropTypes.oneOf(colorNames),
     /** Other class names*/
     className: PropTypes.string,
     title: PropTypes.string,

--- a/component-lib/src/atoms/SvgIcon/SvgIcon.pcss
+++ b/component-lib/src/atoms/SvgIcon/SvgIcon.pcss
@@ -1,29 +1,109 @@
 .svg-icon {
-    &.svg-icon--white * {
-        fill: var(--white);
-    }
+
+    /* Primary colour palette */
 
     &.svg-icon--black * {
         fill: var(--black);
     }
 
-    &.svg-icon--purple * {
+    &.svg-icon--core-purple * {
         fill: var(--core-purple);
-    }
-
-    &.svg-icon--grey * {
-        fill: var(--grey);
     }
 
     &.svg-icon--light-grey * {
         fill: var(--light-grey);
     }
 
-    &.svg-icon--green * {
-        fill: var(--green);
+    &.svg-icon--white * {
+        fill: var(--white);
     }
 
+
+    /* Accent colour palette */
+
+    &.svg-icon--black-purple * {
+        fill: var(--black-purple);
+    }
+
+    &.svg-icon--dark-blue * {
+        fill: var(--dark-blue);
+    }
+
+    &.svg-icon--dark-core-purple * {
+        fill: var(--dark-core-purple);
+    }
+    
+    &.svg-icon--dark-green * {
+        fill: var(--dark-green);
+    }
+    
     &.svg-icon--dark-grey * {
         fill: var(--dark-grey);
+    }
+    
+    &.svg-icon--dark-pink * {
+        fill: var(--dark-pink);
+    }
+    
+    &.svg-icon--dark-purple * {
+        fill: var(--dark-purple);
+    }
+    
+    &.svg-icon--dark-red * {
+        fill: var(--dark-red);
+    }
+    
+    &.svg-icon--dark-teal * {
+        fill: var(--dark-teal);
+    }
+    
+    &.svg-icon--deep-purple * {
+        fill: var(--deep-purple);
+    }
+    
+    &.svg-icon--light-core-purple * {
+        fill: var(--light-core-purple);
+    }
+    
+    &.svg-icon--light-green * {
+        fill: var(--light-green);
+    }
+    
+    &.svg-icon--orange * {
+        fill: var(--orange);
+    }
+    
+    &.svg-icon--pink * {
+        fill: var(--pink);
+    }
+    
+    &.svg-icon--red * {
+        fill: var(--red);
+    }
+
+
+    /* Additional colors */
+    
+    &.svg-icon--darkest-grey * {
+        fill: var(--darkest-grey);
+    }
+    
+    &.svg-icon--border-grey * {
+        fill: var(--border-grey);
+    }
+
+
+    /* Outdated !!! */
+
+    &.svg-icon--grey * {
+        fill: var(--grey);
+    }
+
+    &.svg-icon--purple * {
+        fill: var(--core-purple);
+    }
+
+    &.svg-icon--green * {
+        fill: var(--green);
     }
 }

--- a/component-lib/src/colors.pcss
+++ b/component-lib/src/colors.pcss
@@ -1,53 +1,53 @@
 /* Telia Company Brand colors. Try to use these instead of custom ones */
+
+/* 
+Primary colour palette
+Our core purple is prominent in everything we do and must be present in all communications. 
+We use white and grey for backgrounds in print and online, to help our pebbles and colours really stand out. 
+They are also used on panels and buttons to add distinction. We use black for text and icons.
+*/
 :root {
     --black: #000000;
-    --white: #FFFFFF;
-    --light-grey: #F2F2F2;
-
     --core-purple: #990AE3;
-    --dark-core-purple: #9B009B;
-    --light-core-purple: #CC00FF;
+    --light-grey: #F2F2F2;
+    --white: #FFFFFF;
+}
 
-    --purple-2: #9933FF;
-    --dark-purple-2: #642C96;
-    --light-purple-2: #AF5AFF;
 
-    --blue: #00CDFF;
+/*
+Accent colour palette
+Our accent palette is used in the following applications: call to action buttons, 
+apps and other various UX contexts, PowerPoint, and our illustrations and infographics.  
+*/
+:root {
+    --black-purple: #1F012F;
     --dark-blue: #0099FF;
-    --light-blue: #00FFFF;
-
-    --teal: #00CDCD;
-    --dark-teal: #009999;
-    --light-teal: #00FFCD;
-
-    --green: #32FF00;
+    --dark-core-purple: #9B009B;
     --dark-green: #00CC66;
-    --light-green: #00FF64;
-
-    --lime: #CDFF32;
     --dark-grey: #A0A0A0;
-    --light-lime: #CDFF99;
-
-    --pink: #FF00CD;
     --dark-pink: #D22DB9;
-    --light-pink: #FF64CD;
-
+    --dark-purple: #642D96;
+    --dark-red: #E12364;
+    --dark-teal: #009999;
+    --deep-purple: #380354;
+    --light-core-purple: #CC00FF;
+    --light-green: #00FF64;
     --orange: #FF9B00;
-    --dark-grey-2: #726E6E;
-    --light-orange: #FFCD65;
-
+    --pink: #FF00CD;
     --red: #FF3264;
-    --dark-red: #FF2364;
-    --light-red: #FF6464;
+}
+
+
+/*
+Additional colors
+*/
+:root {
+    --darkest-grey: #757575;
+    --border-grey: #BFBFBF;
 }
 
 /* Custom colours. Try to add as few as possible new ones, and pick from the Telia Company Brand colors above. */
 :root {
-    --grey: #DEDEDE;
-    --grey-darker: #D8D8D8;
-
-    --emerald: #3ED35F;
-    --venetian-red: #D0021B;
     --alert-red: #ffd3e0;
     --alert-dark-red: #ff2365;
     --alert-green: #ddf1e7;
@@ -55,4 +55,21 @@
     --alert-dark-yellow: #ffcd64;
     --alert-blue: #e5f4ff;
     --alert-dark-blue: #0099ff;
+    --blue: #00CDFF;
+    --dark-grey-2: #726E6E;
+    --dark-purple-2: #642C96;
+    --emerald: #3ED35F;
+    --green: #32FF00;
+    --grey: #DEDEDE;
+    --grey-darker: #D8D8D8;
+    --light-purple-2: #AF5AFF;
+    --light-blue: #00FFFF;
+    --light-lime: #CDFF99;
+    --light-orange: #FFCD65;
+    --light-red: #FF6464;
+    --light-pink: #FF64CD;
+    --light-teal: #00FFCD;
+    --lime: #CDFF32;
+    --teal: #00CDCD;
+    --venetian-red: #D0021B;
 }

--- a/component-lib/src/constants.js
+++ b/component-lib/src/constants.js
@@ -1,0 +1,32 @@
+/* !!! */
+/* grey OUTDATED, do not use */
+/* purple OUTDATED, do not use */
+/* green OUTDATED, do not use */
+
+export const colorNames = [
+  'black',
+  'core-purple',
+  'light-grey',
+  'white',
+  'black-purple',
+  'dark-blue',
+  'dark-core-purple',
+  'dark-green',
+  'dark-grey',
+  'dark-pink',
+  'dark-purple',
+  'dark-red',
+  'dark-teal',
+  'deep-purple',
+  'light-core-purple',
+  'light-green',
+  'orange',
+  'pink',
+  'red',
+  'darkest-grey',
+  'border-grey',
+  'grey',
+  'purple',
+  'green',
+  'none'
+] 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "run-s clean generate-static-data generate-component-docs && run-p dev:server css:watch:component-lib css:watch:sg",
     "dev:server": "cross-env NODE_ENV=development LOCAL_DEV=true node server.js",
     "git:checkout-master-and-pull": "git checkout master && git pull --rebase",
-    "generate-component-docs": "react-docgen ./component-lib/src --out ./src/component-docs.json --extension [jsx] --exclude index.js --exclude utils.js --pretty",
+    "generate-component-docs": "react-docgen ./component-lib/src --out ./src/component-docs.json --extension [jsx] --exclude index.js --exclude utils.js --exclude constants.js --pretty",
     "generate-static-data": "node scripts/generate-static-data.js",
     "generate-zip": "node scripts/generate-zip-file.js",
     "heroku-prebuild": "cross-env NODE_ENV=production && npm run build:component-lib",

--- a/src/colors.json
+++ b/src/colors.json
@@ -15,9 +15,10 @@
           "White": {
             "hex": "#FFFFFF",
             "textColor": "#000000",
-            "priority": "2"
+            "priority": "2",
+            "boxShadow": true
           },
-          "Grey": {
+          "Light Grey": {
             "hex": "#F2F2F2",
             "textColor": "#000000",
             "priority": "2"
@@ -36,48 +37,62 @@
             "hex": "#CC00FF",
             "textColor": "#000000"
           },
-          "Dark Blue": {
-            "hex": "#0099FF",
-            "textColor": "#000000"
-          },
-          "Dark Teal": {
-            "hex": "#009999",
-            "textColor": "#000000"
-          },
-          "Dark Green": {
-            "hex": "#00CC66",
+          "Pink": {
+            "hex": "#FF00CD",
             "textColor": "#000000"
           },
           "Dark Pink": {
             "hex": "#D22DB9",
             "textColor": "#000000"
           },
-          "Pink": {
-            "hex": "#FF00CD",
+          "Dark Blue": {
+            "hex": "#0099FF",
             "textColor": "#000000"
+          },
+          "Red": {
+            "hex": "#FF3264",
+            "textColor": "#000000"
+          },
+          "Dark Red": {
+            "hex": "#E12364",
+            "textColor": "#FFFFFF"
           },
           "Orange": {
             "hex": "#FF9B00",
+            "textColor": "#000000"
+          },
+          "Light Green": {
+            "hex": "#99FF64",
+            "textColor": "#000000"
+          },
+          "Dark Green": {
+            "hex": "#00CC66",
+            "textColor": "#000000"
+          },
+          "Dark Teal": {
+            "hex": "#009999",
             "textColor": "#000000"
           },
           "Dark Grey": {
             "hex": "#A0A0A0",
             "textColor": "#000000"
           },
+          "Deep Purple": {
+            "hex": "#380354",
+            "textColor": "#FFFFFF"
+          },
+          "Black Purple": {
+            "hex": "#1F012F",
+            "textColor": "#FFFFFF"
+          }
+    },
+    {
           "Darkest Grey": {
             "hex": "#757575",
             "textColor": "#FFFFFF"
           },
-          "Border grey": {
+          "Border Grey": {
             "hex": "#BFBFBF",
-            "textColor": "#000000"
-          },
-          "Dark Red": {
-            "hex": "#E12364",
-            "textColor": "#000000"
-          },
-          "Red": {
-            "hex": "#FF3264",
             "textColor": "#000000"
           }
     }

--- a/src/components/common/Color.jsx
+++ b/src/components/common/Color.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import classnames from 'classnames';
 
-const Color = ({ name, hex, textColor, priority }) =>
+const Color = ({ name, hex, textColor, priority, boxShadow }) =>
     <div className="sg-color">
         <span className={classnames("sg-color__circle", 
             priority === "1" ? "sg-color__circle-large" : null, 
-            priority === "2" ? "sg-color__circle-medium" : null)} 
+            priority === "2" ? "sg-color__circle-medium" : null,
+            boxShadow ? "sg-color__box-shadow" : null)} 
             style={{ backgroundColor: hex }}></span>
         <div align="center" className="sg-color__name">{name}</div>
         <div align="center" className="sg-color__hex">{hex}</div>

--- a/src/components/examples/atoms/SvgIcon/Default.js
+++ b/src/components/examples/atoms/SvgIcon/Default.js
@@ -3,10 +3,10 @@ import { SvgIcon } from '@telia/styleguide';
 
 const DefaultSvgIcon = () => (
     <div>
-        <SvgIcon iconName="ico_heart" color="light-grey" />
-        <SvgIcon iconName="ico_heart" color="grey" />
         <SvgIcon iconName="ico_heart" color="black" />
-        <SvgIcon iconName="ico_heart" color="purple" />
+        <SvgIcon iconName="ico_heart" color="core-purple" />
+        <SvgIcon iconName="ico_heart" color="light-grey" />
+        <SvgIcon iconName="ico_heart" color="white" style={{background: '#990AE3'}} />
     </div>
 );
 

--- a/src/components/pages/HomePage.jsx
+++ b/src/components/pages/HomePage.jsx
@@ -24,7 +24,7 @@ const HomePage = () =>
 
         <div className="container container--small container--extra-padding-top">
             <Heading level={2} text="Color Palette" />
-            <p className="paragraph">The color palette below was taken from the Telia Company design document (TODO: source) and shows the recommended font color to give the correct contrast.</p>
+            <p className="paragraph">The color palette below was taken from the <a href="https://brandhub.teliacompany.com/document/14#/colour-palette/our-colour-palette" target="_blank">Telia Company design document</a> and shows the recommended font color to give the correct contrast.</p>
         </div>
         <div className="container container--medium">
             <div className="sg-colors-wrapper">
@@ -35,6 +35,11 @@ const HomePage = () =>
             </div>
             <div className="sg-colors-wrapper">
                 {_.map(colors[2], (color, name) => <Color key={name} name={name} {...color} />)}
+            </div>
+            <hr style={{marginTop: '2rem'}} />
+            <div className="sg-colors-wrapper">
+                <p>Additional colors</p>
+                {_.map(colors[3], (color, name) => <Color key={name} name={name} {...color} />)}
             </div>
         </div>
 

--- a/src/css/index.pcss
+++ b/src/css/index.pcss
@@ -11,7 +11,7 @@ body {
 
 .sg-color {
     margin: 10px auto;
-    padding: 20px;
+    padding: 18px;
     display: inline-block;
 }
 
@@ -24,30 +24,33 @@ body {
 }
 
 .sg-color__circle {
-    border: 1px solid #A0A0A0;
     border-radius: 50%;
     display: block;
-    height: 150px;
+    height: 100px;
     margin: auto;
-    width: 150px;
+    width: 100px;
 }
 
 .sg-color__text-color-hint {
     align: center;
-    border: 1px solid #A0A0A0;
+    /* border: 1px solid #A0A0A0; */
     margin: auto;
     padding: 5px;
     width: 120px;
 }
 
+.sg-color__box-shadow {
+    box-shadow: 0px 0px 20px -10px rgba(0,0,0,1);
+}
+
 .sg-color__circle-large {
-    height: 250px;
-    width: 250px;
+    height: 160px;
+    width: 160px;
 }
 
 .sg-color__circle-medium {
-    height: 200px;
-    width: 200px;
+    height: 130px;
+    width: 130px;
 }
 
 .sg-colors-wrapper {


### PR DESCRIPTION
=== COLOR CLEANUP ===

We had some outdated colors in the styleguide that have now been updated. 

Dont worry!
The old one still works ...

If you are using "grey" or "green", try to find some other alternatives in the styleguide color palette.
"purple" = "core-purple", please use "core-purple" instead, so there will be no misunderstandings.

There are 3 new colors added:
![Screenshot 2019-09-23 at 18 06 14](https://user-images.githubusercontent.com/37070968/65442689-edbca000-de2c-11e9-9994-19cc8bbe8bc1.png)



Additional colors means that they are not from the official Telia palette, but something Telia Norway
have created:
![Screenshot 2019-09-23 at 17 54 07](https://user-images.githubusercontent.com/37070968/65441719-2b202e00-de2b-11e9-829e-74ff00b93995.png)

SvgIcon supports all the colors now :D


We still got some custom colors that we want to get rid of. 
Are anyone using one of theese colors?

    --blue: #00CDFF;
    --dark-grey-2: #726E6E;
    --dark-purple-2: #642C96;
    --emerald: #3ED35F;
    --green: #32FF00;
    --grey: #DEDEDE;
    --grey-darker: #D8D8D8;
    --lime: #CDFF32;
    --teal: #00CDCD;
    --venetian-red: #D0021B;
