### PR TITLE
Add aria-label to have properly cased close button text on Box component

### DIFF
--- a/component-lib/src/atoms/Box/Box.jsx
+++ b/component-lib/src/atoms/Box/Box.jsx
@@ -77,7 +77,7 @@ export default class Box extends React.Component {
                     : <div className="box__speech-bubble box__speech-bubble--empty"></div>}
                 {this.state.isExpanded ?
                     <button className="box__close-expanded-info" onClick={this.closeBoxClick} aria-controls={this.props.id}>
-                        <span className="box__close-text">LUKK</span>
+                        <span className="box__close-text" aria-label="Lukk">LUKK</span>
                         <SvgIcon aria-hidden="true" className="box__close-icon" iconName="ico_delete" color="black" />
                     </button> : null}
                 {this.props.children}

--- a/component-lib/src/atoms/Box/Box.pcss
+++ b/component-lib/src/atoms/Box/Box.pcss
@@ -245,6 +245,7 @@
         right: 0;
         text-align: left;
         top: 0;
+        bottom: 0;
         width: auto;
 
         &:hover {

--- a/component-lib/src/atoms/Box/Box.pcss
+++ b/component-lib/src/atoms/Box/Box.pcss
@@ -245,7 +245,6 @@
         right: 0;
         text-align: left;
         top: 0;
-        bottom: 0;
         width: auto;
 
         &:hover {


### PR DESCRIPTION
Uppercase texts are read as abbreviations (letter-by-letter) by screen readers.
Also make sure button stretches out to bottom as well.