### PR TITLE
Fix warnings in QuantityPicker and ToggleButton, change font-size of Quote

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -15,6 +15,9 @@ For Major and Minor changes in version you must notify everyone in the #stylegui
 
 Only noteworthy versions shown (minor changes are omitted).
 
+## 1.29.7
+- Changed font-size of text in the Quote component
+
 ## 1.29.6
 - Lint and Prettier fix
 - Menu search: Shows spinner when loading and input field are disabled

--- a/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
+++ b/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
@@ -7,7 +7,7 @@ import QuantityButton from './QuantityButton';
  * Category: Buttons
  */
 
-const QuantityPicker = ({ onChangeQuantity, quantity, minQuantity, maxQuantity, addText, reduceText }) => {
+const QuantityPicker = ({ onChangeQuantity, quantity, minQuantity, maxQuantity, addText, reduceText, inputName }) => {
   if (isNaN(quantity)) {
     quantity = '';
   }
@@ -29,7 +29,7 @@ const QuantityPicker = ({ onChangeQuantity, quantity, minQuantity, maxQuantity, 
             onChangeQuantity(Math.max(Math.min(parseInt(event.target.value), maxQuantity), minQuantity))
           }
           type="number"
-          name="Tast inn antall"
+          name={inputName}
           value={quantity}
         />
       </label>
@@ -50,13 +50,15 @@ QuantityPicker.propTypes = {
   maxQuantity: PropTypes.number,
   addText: PropTypes.string,
   reduceText: PropTypes.string,
+  inputName: PropTypes.string,
 };
 
 QuantityPicker.defaultProps = {
   minQuantity: Number.MIN_SAFE_INTEGER,
   maxQuantity: Number.MAX_SAFE_INTEGER,
   addText: 'Øk antall',
-  reduceText: 'Reuser antall',
+  reduceText: 'Reduser antall',
+  inputName: 'Tast inn antall',
 };
 
 QuantityButton.propTypes = {

--- a/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
+++ b/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
@@ -30,8 +30,9 @@ const QuantityPicker = ({
         text={reduceText}
       />
 
-      <span className="quantity-picker__input-container">
+      <span className="quantity-picker__container">
         <TextBoxWithLabel
+          className="quantity-picker__input"
           max={maxQuantity}
           min={minQuantity}
           onChange={event =>

--- a/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
+++ b/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
@@ -25,11 +25,12 @@ const QuantityPicker = ({
     <div className="quantity-picker">
       <QuantityButton
         icon="ico_minus"
-        isDisabled={quantity <= minQuantity || quantity === ''}
+        isDisabled={quantity <= minQuantity || !quantity}
         onClick={() => onChangeQuantity(Math.max(quantity - 1, minQuantity))}
         text={reduceText}
       />
-      <div className="quantity-picker__input-container">
+
+      <span className="quantity-picker__input-container">
         <TextBoxWithLabel
           max={maxQuantity}
           min={minQuantity}
@@ -41,10 +42,11 @@ const QuantityPicker = ({
           labelText={quantityLabel}
           hideLabel
         />
-      </div>
+      </span>
+
       <QuantityButton
         icon="ico_add"
-        isDisabled={quantity >= maxQuantity || quantity === ''}
+        isDisabled={quantity >= maxQuantity || !quantity}
         onClick={() => onChangeQuantity(Math.min(quantity + 1, maxQuantity))}
         text={addText}
       />

--- a/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
+++ b/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
@@ -1,4 +1,4 @@
-import React  from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import QuantityButton from './QuantityButton';
 
@@ -7,53 +7,63 @@ import QuantityButton from './QuantityButton';
  * Category: Buttons
  */
 
-const QuantityPicker = ({ onChangeQuantity, quantity, minQuantity, maxQuantity, addText, reduceText }) => (
+const QuantityPicker = ({ onChangeQuantity, quantity, minQuantity, maxQuantity, addText, reduceText }) => {
+  if (isNaN(quantity)) {
+    quantity = '';
+  }
+
+  return (
     <div className="quantity-picker">
-        <QuantityButton
-            icon="ico_minus"
-            isDisabled={quantity <= minQuantity}
-            onClick={() => onChangeQuantity(Math.max(quantity - 1, minQuantity))}
-            text={reduceText}
+      <QuantityButton
+        icon="ico_minus"
+        isDisabled={quantity <= minQuantity}
+        onClick={() => onChangeQuantity(Math.max(quantity - 1, minQuantity))}
+        text={reduceText}
+      />
+      <label className="quantity-picker__label">
+        <input
+          className="textbox quantity-picker__input"
+          max={maxQuantity}
+          min={minQuantity}
+          onChange={event =>
+            onChangeQuantity(Math.max(Math.min(parseInt(event.target.value), maxQuantity), minQuantity))
+          }
+          type="number"
+          name="Tast inn antall"
+          value={quantity}
         />
-        <label className="quantity-picker__label">
-            <input
-                className="textbox quantity-picker__input"
-                max={maxQuantity}
-                min={minQuantity}
-                onChange={(event) => onChangeQuantity(Math.max(Math.min(parseInt(event.target.value), maxQuantity), minQuantity))}
-                type="number"
-                value={quantity} />
-        </label>
-        <QuantityButton
-            icon="ico_add"
-            isDisabled={quantity >= maxQuantity}
-            onClick={() => onChangeQuantity(Math.min(quantity + 1, maxQuantity))}
-            text={addText}
-        />
+      </label>
+      <QuantityButton
+        icon="ico_add"
+        isDisabled={quantity >= maxQuantity}
+        onClick={() => onChangeQuantity(Math.min(quantity + 1, maxQuantity))}
+        text={addText}
+      />
     </div>
-);
+  );
+};
 
 QuantityPicker.propTypes = {
-    onChangeQuantity: PropTypes.func,
-    quantity: PropTypes.number.isRequired,
-    minQuantity: PropTypes.number,
-    maxQuantity: PropTypes.number,
-    addText: PropTypes.string,
-    reduceText: PropTypes.string
+  onChangeQuantity: PropTypes.func,
+  quantity: PropTypes.number.isRequired,
+  minQuantity: PropTypes.number,
+  maxQuantity: PropTypes.number,
+  addText: PropTypes.string,
+  reduceText: PropTypes.string,
 };
 
 QuantityPicker.defaultProps = {
-    minQuantity: Number.MIN_SAFE_INTEGER,
-    maxQuantity: Number.MAX_SAFE_INTEGER,
-    addText: 'Øk antall',
-    reduceText: 'Reuser antall'
+  minQuantity: Number.MIN_SAFE_INTEGER,
+  maxQuantity: Number.MAX_SAFE_INTEGER,
+  addText: 'Øk antall',
+  reduceText: 'Reuser antall',
 };
 
 QuantityButton.propTypes = {
-    icon: PropTypes.string,
-    isDisabled: PropTypes.bool,
-    onClick: PropTypes.func,
-    text: PropTypes.string
+  icon: PropTypes.string,
+  isDisabled: PropTypes.bool,
+  onClick: PropTypes.func,
+  text: PropTypes.string,
 };
 
 export default QuantityPicker;

--- a/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
+++ b/component-lib/src/atoms/QuantityPicker/QuantityPicker.jsx
@@ -1,13 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import QuantityButton from './QuantityButton';
+import TextBoxWithLabel from '../../molecules/TextBoxWithLabel/TextBoxWithLabel';
 
 /**
  * Status: *finished*.
  * Category: Buttons
  */
 
-const QuantityPicker = ({ onChangeQuantity, quantity, minQuantity, maxQuantity, addText, reduceText, inputName }) => {
+const QuantityPicker = ({
+  onChangeQuantity,
+  quantity,
+  minQuantity,
+  maxQuantity,
+  addText,
+  reduceText,
+  quantityLabel,
+}) => {
   if (isNaN(quantity)) {
     quantity = '';
   }
@@ -16,26 +25,26 @@ const QuantityPicker = ({ onChangeQuantity, quantity, minQuantity, maxQuantity, 
     <div className="quantity-picker">
       <QuantityButton
         icon="ico_minus"
-        isDisabled={quantity <= minQuantity}
+        isDisabled={quantity <= minQuantity || quantity === ''}
         onClick={() => onChangeQuantity(Math.max(quantity - 1, minQuantity))}
         text={reduceText}
       />
-      <label className="quantity-picker__label">
-        <input
-          className="textbox quantity-picker__input"
+      <div className="quantity-picker__input-container">
+        <TextBoxWithLabel
           max={maxQuantity}
           min={minQuantity}
           onChange={event =>
             onChangeQuantity(Math.max(Math.min(parseInt(event.target.value), maxQuantity), minQuantity))
           }
           type="number"
-          name={inputName}
           value={quantity}
+          labelText={quantityLabel}
+          hideLabel
         />
-      </label>
+      </div>
       <QuantityButton
         icon="ico_add"
-        isDisabled={quantity >= maxQuantity}
+        isDisabled={quantity >= maxQuantity || quantity === ''}
         onClick={() => onChangeQuantity(Math.min(quantity + 1, maxQuantity))}
         text={addText}
       />
@@ -50,7 +59,7 @@ QuantityPicker.propTypes = {
   maxQuantity: PropTypes.number,
   addText: PropTypes.string,
   reduceText: PropTypes.string,
-  inputName: PropTypes.string,
+  quantityLabel: PropTypes.string,
 };
 
 QuantityPicker.defaultProps = {
@@ -58,7 +67,7 @@ QuantityPicker.defaultProps = {
   maxQuantity: Number.MAX_SAFE_INTEGER,
   addText: 'Øk antall',
   reduceText: 'Reduser antall',
-  inputName: 'Tast inn antall',
+  quantityLabel: 'Tast inn antall',
 };
 
 QuantityButton.propTypes = {

--- a/component-lib/src/atoms/QuantityPicker/QuantityPicker.pcss
+++ b/component-lib/src/atoms/QuantityPicker/QuantityPicker.pcss
@@ -4,24 +4,25 @@
     display: flex;
     align-items: center;
 
-    &__input-container {
+    &__container {
         margin: 0 1rem;
         
-        input {
-            display: inline-block;
-            font-size: 1rem;
-            text-align: center;
-            -moz-appearance: textfield;
+    }
 
-            &::selection {
-                background-color: var(--core-purple);
-                color: var(--white);
-            }
-        
-            &::-webkit-inner-spin-button,
-            &::-webkit-outer-spin-button {
-                -webkit-appearance: none;
-            }
+    &__input {
+        display: inline-block;
+        font-size: 1rem;
+        text-align: center;
+        -moz-appearance: textfield;
+
+        &::selection {
+            background-color: var(--core-purple);
+            color: var(--white);
+        }
+    
+        &::-webkit-inner-spin-button,
+        &::-webkit-outer-spin-button {
+            -webkit-appearance: none;
         }
     }
 

--- a/component-lib/src/atoms/QuantityPicker/QuantityPicker.pcss
+++ b/component-lib/src/atoms/QuantityPicker/QuantityPicker.pcss
@@ -4,26 +4,27 @@
     display: flex;
     align-items: center;
 
-    &__input {
-        display: inline-block;
-        font-size: 1rem;
-        text-align: center;
-        -moz-appearance: textfield;
-
-        &::selection {
-            background-color: var(--core-purple);
-            color: var(--white);
-        }
-
-        &::-webkit-inner-spin-button,
-        &::-webkit-outer-spin-button {
-            -webkit-appearance: none;
-        }
-    }
-
-    &__label {
+    &__input-container {
         margin: 0 1rem;
+        
+        input {
+            display: inline-block;
+            font-size: 1rem;
+            text-align: center;
+            -moz-appearance: textfield;
+
+            &::selection {
+                background-color: var(--core-purple);
+                color: var(--white);
+            }
+        
+            &::-webkit-inner-spin-button,
+            &::-webkit-outer-spin-button {
+                -webkit-appearance: none;
+            }
+        }
     }
+
 }
 
 .quantity-picker__button {

--- a/component-lib/src/atoms/Quote/Quote.pcss
+++ b/component-lib/src/atoms/Quote/Quote.pcss
@@ -32,7 +32,7 @@
     }
 
     &__text {
-        font-size: 1.2rem;
+        font-size: 1.1rem;
         font-style: italic;
         line-height: 1.3;
         margin: 0;
@@ -41,7 +41,7 @@
         flex: 1 0 33%;
 
         @media all and (min-width: 633px) {
-            font-size: 1.2rem;
+            font-size: 1.3rem;
             line-height: 1.2;
         }
     }

--- a/component-lib/src/atoms/ToggleButton/ToggleButton.jsx
+++ b/component-lib/src/atoms/ToggleButton/ToggleButton.jsx
@@ -11,25 +11,44 @@ import cn from 'classnames';
  * This component should be used when there are things that can be toggled on and off.
  * Extra `descriptionText` can be displayed below the toggle button.
  */
-const ToggleButton = ({ id, labelText, descriptionText, defaultChecked = false, checked, onChange, toggleOnLeftSide = false }) => (
-    <div className={cn('toggle-button', {
-        'left-side': toggleOnLeftSide,
-        'right-side': !toggleOnLeftSide
-    })}>
-        <input id={id} className="toggle-button__checkbox" type="checkbox" onChange={onChange} checked={checked} defaultChecked={defaultChecked} />
-        <label htmlFor={id} className="toggle-button__label">{labelText}</label>
-        {descriptionText ? <p className="toggle-button__description">{descriptionText}</p> : null}
-    </div>
+const ToggleButton = ({
+  id,
+  labelText,
+  descriptionText,
+  defaultChecked = undefined,
+  checked,
+  onChange,
+  toggleOnLeftSide = false,
+}) => (
+  <div
+    className={cn('toggle-button', {
+      'left-side': toggleOnLeftSide,
+      'right-side': !toggleOnLeftSide,
+    })}
+  >
+    <input
+      id={id}
+      className="toggle-button__checkbox"
+      type="checkbox"
+      onChange={onChange}
+      checked={checked}
+      defaultChecked={defaultChecked}
+    />
+    <label htmlFor={id} className="toggle-button__label">
+      {labelText}
+    </label>
+    {descriptionText ? <p className="toggle-button__description">{descriptionText}</p> : null}
+  </div>
 );
 
 ToggleButton.propTypes = {
-    defaultChecked: PropTypes.bool,
-    id: PropTypes.string.isRequired,
-    labelText: PropTypes.string.isRequired,
-    onChange: PropTypes.func,
-    checked: PropTypes.bool,
-    descriptionText: PropTypes.string,
-    toggleOnLeftSide: PropTypes.bool
+  defaultChecked: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  labelText: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  checked: PropTypes.bool,
+  descriptionText: PropTypes.string,
+  toggleOnLeftSide: PropTypes.bool,
 };
 
 export default ToggleButton;

--- a/component-lib/src/atoms/ToggleButton/ToggleButton.jsx
+++ b/component-lib/src/atoms/ToggleButton/ToggleButton.jsx
@@ -15,7 +15,7 @@ const ToggleButton = ({
   id,
   labelText,
   descriptionText,
-  defaultChecked = undefined,
+  defaultChecked,
   checked,
   onChange,
   toggleOnLeftSide = false,


### PR DESCRIPTION
- Fix warning in ToggleButton component by setting defaultChecked to undefined if the prop is not explicitly set
- Fix warning in QuantityPicker which used to happen when erasing the input field
- Minor change to font-size of text in Quote component so it's more responsive. This is the sizes we use in RapidShop, so thought I would make the same change here.
- Add a name field to the input component of QuantityPicker for improved accessability.

Looks like the linter also automatically makes some formatting changes when pushing.