### PR TITLE
quantity picker browser support

### DIFF
--- a/component-lib/src/atoms/QuantityPicker/QuantityPicker.pcss
+++ b/component-lib/src/atoms/QuantityPicker/QuantityPicker.pcss
@@ -6,7 +6,7 @@
 
     &__container {
         margin: 0 1rem;
-        
+        width: 3.5rem;
     }
 
     &__input {
@@ -19,7 +19,7 @@
             background-color: var(--core-purple);
             color: var(--white);
         }
-    
+
         &::-webkit-inner-spin-button,
         &::-webkit-outer-spin-button {
             -webkit-appearance: none;
@@ -29,8 +29,8 @@
 }
 
 .quantity-picker__button {
-    margin: 0 !important;
-    padding: 0 !important;
+    margin: 0;
+    padding: 0;
     height: 2.5rem;
     width: 2.5rem;
 


### PR DESCRIPTION
Fix that all browsers other than chrome displayed like this:
![image](https://user-images.githubusercontent.com/6595638/68943143-a1e20380-07aa-11ea-8e97-8be25b954d03.png)
