### PR TITLE
Add optional footer to accordion

### DIFF
--- a/component-lib/src/molecules/Accordion/Accordion.jsx
+++ b/component-lib/src/molecules/Accordion/Accordion.jsx
@@ -25,6 +25,7 @@ const Accordion = ({
   buttonType,
   onButtonClick,
   toggleIsExpanded,
+  footer,
 }) => {
   function accordionHeaderClicked() {
     toggleIsExpanded();
@@ -67,6 +68,7 @@ const Accordion = ({
       <div className="accordion__panel rich-text" id={id}>
         {children}
       </div>
+      {footer}
     </section>
   );
 };
@@ -85,6 +87,7 @@ Accordion.propTypes = {
   imageUrl: PropTypes.string,
   onButtonClick: PropTypes.func,
   toggleIsExpanded: PropTypes.func,
+  footer: PropTypes.node,
 };
 
 export default Accordion;


### PR DESCRIPTION
Add optional component at the bottom of the accordion component. In RapidShop we use it to add a color picker: 
![image](https://user-images.githubusercontent.com/11172530/69870545-800b7500-12b0-11ea-8f42-629f5ae7c507.png)
