### PR TITLE
Automatically build icons when publishing to NPM

### DIFF
--- a/ci/tasks/update-and-publish-npm/task.sh
+++ b/ci/tasks/update-and-publish-npm/task.sh
@@ -22,6 +22,7 @@ echo "Update component lib version:"
 cd component-lib
 npm version ${update_type} --no-git-tag
 
+npm run build:icons
 npm run build
 
 export NPM_TOKEN=${npm_token}


### PR DESCRIPTION
This change automatically runs `npm run build:icons` when publishing to NPM.

I'm a bit torn on this -- a better solution would probably be to have a bot perform the change in the repo directly (so the generated files are automatically committed to the repo too).

But we do have a bit of autogeneration on publish already, so I guess it's a small improvement :man_shrugging: 