### PR TITLE
Add hook and fix paging

### DIFF
--- a/component-lib/src/business/Table/Table.pcss
+++ b/component-lib/src/business/Table/Table.pcss
@@ -65,9 +65,9 @@
 
 .table-paging {
     padding-top: .7rem;
+
     &__text {
         margin: 0 1rem;
-
     }
 
     &__per-page {

--- a/component-lib/src/business/Table/Table.stories.tsx
+++ b/component-lib/src/business/Table/Table.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 const subscribers = require('./sampledata.json');
 
-import { useTableState } from './tableHooks';
+import { useTableState } from './useTableState';
 
 const headings = [
     { id: "formal_name",
@@ -53,7 +53,7 @@ export const Standard = () => {
 };
 
 export const WithPaging = () => {
-    const [ state, { changePage, changePerPage } ] = useTableState({ paging: true, data: subscribers });
+    const [ state, { setPage, setPerPage } ] = useTableState({ paging: true, data: subscribers });
 
     return (<>
         <Table headings={headings}
@@ -62,8 +62,8 @@ export const WithPaging = () => {
                 to={state.to}
                 dataLength={subscribers.length}
                 perPage={state.perPage}
-                onPageChange={changePage}
-                onPerPageChange={changePerPage}
+                onPageChange={setPage}
+                onPerPageChange={setPerPage}
             />}
         >
             {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
@@ -81,7 +81,7 @@ export const WithPaging = () => {
 };
 
 export const WithClickableRows = () => {
-    const [ state, { changePage, changePerPage } ] = useTableState({ data: subscribers });
+    const [ state, { setPage, setPerPage } ] = useTableState({ data: subscribers });
 
     return (<>
         <Table headings={headings}
@@ -90,8 +90,8 @@ export const WithClickableRows = () => {
                 to={state.to}
                 dataLength={subscribers.length}
                 perPage={state.perPage}
-                onPageChange={changePage}
-                onPerPageChange={changePerPage}
+                onPageChange={setPage}
+                onPerPageChange={setPerPage}
             />}
         >
             {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
@@ -110,7 +110,7 @@ export const WithClickableRows = () => {
 };
 
 export const WithClickableRowsAndCells = () => {
-    const [ state, { changePage, changePerPage } ] = useTableState({ data: subscribers });
+    const [ state, { setPage, setPerPage } ] = useTableState({ data: subscribers });
 
     return (<>
         <Table headings={headings}
@@ -119,8 +119,8 @@ export const WithClickableRowsAndCells = () => {
                 to={state.to}
                 dataLength={subscribers.length}
                 perPage={state.perPage}
-                onPageChange={changePage}
-                onPerPageChange={changePerPage}
+                onPageChange={setPage}
+                onPerPageChange={setPerPage}
             />}
         >
             {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
@@ -139,12 +139,12 @@ export const WithClickableRowsAndCells = () => {
 };
 
 export const Selectable = () => {
-    const [ state, { changePage, changePerPage, toggleAll, toggleRow } ] = useTableState({ data: subscribers, paging: true, selecting: true, selectionId: 'subscription_id' });
+    const [ state, { setPage, setPerPage, setSelectAll, setSelectRow } ] = useTableState({ data: subscribers, paging: true, selecting: true, selectionId: 'subscription_id' });
 
     return (<>
         <Table headings={headings}
 
-            onSelectAll={toggleAll}
+            onSelectAll={setSelectAll}
             allSelected={state.allSelected}
             selected={state.selectedRows}
             paging={<TablePagingControls
@@ -152,15 +152,15 @@ export const Selectable = () => {
                 to={state.to}
                 dataLength={subscribers.length}
                 perPage={state.perPage}
-                onPageChange={changePage}
-                onPerPageChange={changePerPage}
+                onPageChange={setPage}
+                onPerPageChange={setPerPage}
             />}
         >
             {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
                 <TableBodyRow
                     selectId={subscriber.subscription_id}
                     key={subscriber.subscription_id}
-                    onSelect={() => toggleRow(subscriber.subscription_id)}
+                    onSelect={() => setSelectRow(subscriber.subscription_id)}
                     selected={state.selectedRows.includes(subscriber.subscription_id)}>
                         {flow(
                             pick([ "formal_name", "subscription_id", "account_id", "account_name", "resource_type", "subscription_type" ]),
@@ -174,20 +174,20 @@ export const Selectable = () => {
 };
 
 export const Sortable = () => {
-    const [ state, { changeSorting, changePage, changePerPage } ] = useTableState({ data: subscribers, paging: true, sorting: true, sortColumn: 'subscription_id' });
+    const [ state, { setSorting, setPage, setPerPage } ] = useTableState({ data: subscribers, paging: true, sorting: true, sortColumn: 'subscription_id' });
 
     return (<>
         <Table headings={headings}
             sortedColumnId={state.sortColumn}
             sortedColumnDirection={state.sortDirection}
-            onClickColumnHeader={(sortId) => changeSorting(sortId)}
+            onClickColumnHeader={(sortId) => setSorting(sortId)}
             paging={<TablePagingControls
                 from={state.from + 1}
                 to={state.to}
                 dataLength={subscribers.length}
                 perPage={state.perPage}
-                onPageChange={changePage}
-                onPerPageChange={changePerPage}
+                onPageChange={setPage}
+                onPerPageChange={setPerPage}
             />}
         >
             {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
@@ -205,31 +205,31 @@ export const Sortable = () => {
 };
 
 export const SortableAndSelectable = () => {
-    const [ state, { changeSorting, changePage, changePerPage, toggleAll, toggleRow } ] = useTableState({ data: subscribers, paging: true, selecting: true, selectionId: 'subscription_id', sorting: true, sortColumn: 'subscription_id' });
+    const [ state, { setSorting, setPage, setPerPage, setSelectAll, setSelectRow } ] = useTableState({ data: subscribers, paging: true, selecting: true, selectionId: 'subscription_id', sorting: true, sortColumn: 'subscription_id' });
 
     return (<>
         <Table headings={headings}
-            onSelectAll={toggleAll}
+            onSelectAll={setSelectAll}
             allSelected={state.allSelected}
             selected={state.selectedRows}
             sortedColumnId={state.sortColumn}
             sortedColumnDirection={state.sortDirection}
-            onClickColumnHeader={(sortId) => changeSorting(sortId)}
+            onClickColumnHeader={(sortId) => setSorting(sortId)}
             paging={<TablePagingControls
                 from={state.from + 1}
                 to={state.to}
                 dataLength={subscribers.length}
                 perPage={state.perPage}
-                onPageChange={changePage}
-                onPerPageChange={changePerPage}
-                amountOfSelectedRows={state.selectedRows.length}
+                onPageChange={setPage}
+                onPerPageChange={setPerPage}
+                numberOfSelectedRows={state.selectedRows.length}
             />}
         >
             {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
                 <TableBodyRow
                     selectId={subscriber.subscription_id}
                     key={subscriber.subscription_id}
-                    onSelect={() => toggleRow(subscriber.subscription_id)}
+                    onSelect={() => setSelectRow(subscriber.subscription_id)}
                     selected={state.selectedRows.includes(subscriber.subscription_id)}>
                         {flow(
                             pick([ "formal_name", "subscription_id", "account_id", "account_name", "resource_type", "subscription_type" ]),

--- a/component-lib/src/business/Table/Table.stories.tsx
+++ b/component-lib/src/business/Table/Table.stories.tsx
@@ -7,100 +7,38 @@ import flow from 'lodash/fp/flow';
 
 export default {
     component: Table,
-    title: 'Business|Table'
+    title: 'Business/Table'
 }
 
 const subscribers = require('./sampledata.json');
 
-const initialState: {
-    selected: Array<string>,
-    allSelected: boolean,
-    sortKey: string,
-    sortDirection: "ASC" | "DESC" | "NONE",
-    currentPerPage: number,
-    currentPage: number,
-    currentFrom: number,
-    currentTo: number,
-    data: Array<any>,
-    sortedData: Array<any>
-} = {
-    selected: [],
-    allSelected: false,
-    sortKey: "subscription_id",
-    sortDirection: "ASC",
-    currentPerPage: 10,
-    currentPage: 1,
-    currentFrom: 0,
-    currentTo: 9,
-    data: [],
-    sortedData: _.sortBy(subscribers, "subscription_id")
-}
+import { useTableState } from './tableHooks';
 
-function reducer(oldState: typeof initialState, action: { type: String, payload: any }): typeof initialState {
-    switch (action.type) {
-        case "SET_DATA": return { ...oldState, data: action.payload.data };
-        case "SET_SORTED_DATA": return { ...oldState, sortedData: action.payload };
-        case "SELECT_ALL": return { ...oldState, selected: oldState.data.map((elem) => elem.subscription_id), allSelected: true };
-        case "DESELECT_ALL": return { ...oldState, selected: [], allSelected: false };
-        case "UNSELECT_ROW": return { ...oldState, selected: oldState.selected.filter((elem) => elem !== action.payload), allSelected: false };
-        case "SELECT_ROW":
-            const newSelected = [...oldState.selected, action.payload];
-            return { ...oldState, selected: newSelected, allSelected: oldState.data.reduce((acc, sub) => acc && newSelected.includes(sub.subscription_id), true) };
-
-        case "SORT_COLUMN":
-            const newSortKey = action.payload;
-            const newSortDirection = newSortKey !== oldState.sortKey ? "ASC" : oldState.sortDirection === "ASC" ? "DESC" : "ASC";
-            return { ...oldState, sortKey: newSortKey, sortDirection: newSortDirection }
-
-        case "SET_PER_PAGE":
-            const newPerPage = action.payload;
-            const possibleNewPage = oldState.currentPage > Math.ceil(subscribers.length / newPerPage) ? Math.ceil(subscribers.length / newPerPage) : oldState.currentPage;
-            const newFrom = (newPerPage * possibleNewPage) - newPerPage;
-            const newTo = (newPerPage * possibleNewPage) - 1 > subscribers.length - 1 ? subscribers.length - 1 : (newPerPage * possibleNewPage) - 1;
-            return { ...oldState, currentPerPage: newPerPage, currentFrom: newFrom, currentTo: newTo, currentPage: possibleNewPage };
-
-        case "SET_PAGE":
-            const newPage = action.payload < 1 ? 1 : action.payload > Math.ceil(subscribers.length / oldState.currentPerPage) ? Math.ceil(subscribers.length / oldState.currentPerPage) : action.payload;
-            const newFrom2 = (oldState.currentPerPage * newPage) - oldState.currentPerPage;
-            const newTo2 = (oldState.currentPerPage * newPage) - 1 > subscribers.length - 1 ? subscribers.length - 1 : (oldState.currentPerPage * newPage) - 1;
-            return { ...oldState, currentPage: newPage, currentFrom: newFrom2, currentTo: newTo2 };
-
-        default:
-            console.warn("Reducer called with unknown action type:", action.type, action);
-            return { ...oldState };
-    }
-}
+const headings = [
+    { id: "formal_name",
+      label: "Navn",
+      rightAligned: false  },
+    { id: "subscription_id",
+      label: "Telefonnummer",
+      rightAligned: true  },
+    { id: "account_id",
+      label: "Avdelingsnummer",
+      rightAligned: true  },
+    { id: "account_name",
+      label: "Avdeling",
+      rightAligned: false  },
+    { id: "resource_type",
+      label: "Enhetstype",
+      rightAligned: false  },
+    { id: "subscription_type",
+      label: "Abonnement",
+      rightAligned: false  }
+];
 
 export const Standard = () => {
-    const [state, dispatch] = React.useReducer(reducer, initialState);
-
-    React.useEffect(() => {
-        dispatch({ type: "SET_DATA", payload: { data: state.sortedData.slice(state.currentFrom, state.currentTo+1) } })
-    }, [ state.currentFrom, state.currentTo, state.sortedData ])
-
-    return (<React.Fragment>
-        <Table headings={[
-            { id: "formal_name",
-              label: "Navn",
-              rightAligned: false  },
-            { id: "subscription_id",
-              label: "Telefonnummer",
-              rightAligned: true  },
-            { id: "account_id",
-              label: "Avdelingsnummer",
-              rightAligned: true  },
-            { id: "account_name",
-              label: "Avdeling",
-              rightAligned: false  },
-            { id: "resource_type",
-              label: "Enhetstype",
-              rightAligned: false  },
-            { id: "subscription_type",
-              label: "Abonnement",
-              rightAligned: false  }
-        ]}
-        >
-            {state.data.map((subscriber: any, index: number) =>
+    return (<>
+        <Table headings={headings} >
+            {subscribers.slice(0, 10).map((subscriber: any, index: number) =>
                 <TableBodyRow
                     key={subscriber.subscription_id}>
                         {flow(
@@ -111,49 +49,24 @@ export const Standard = () => {
                 </TableBodyRow>)}
         </Table>
 
-    </React.Fragment>)
+    </>)
 };
 
 export const WithPaging = () => {
-    const [state, dispatch] = React.useReducer(reducer, initialState);
+    const [ state, { changePage, changePerPage } ] = useTableState({ paging: true, data: subscribers });
 
-    React.useEffect(() => {
-        dispatch({ type: "SET_DATA", payload: { data: state.sortedData.slice(state.currentFrom, state.currentTo+1) } })
-    }, [ state.currentFrom, state.currentTo, state.sortedData ])
-
-    return (<React.Fragment>
-        <Table headings={[
-            { id: "formal_name",
-              label: "Navn",
-              rightAligned: false  },
-            { id: "subscription_id",
-              label: "Telefonnummer",
-              rightAligned: true  },
-            { id: "account_id",
-              label: "Avdelingsnummer",
-              rightAligned: true  },
-            { id: "account_name",
-              label: "Avdeling",
-              rightAligned: false  },
-            { id: "resource_type",
-              label: "Enhetstype",
-              rightAligned: false  },
-            { id: "subscription_type",
-              label: "Abonnement",
-              rightAligned: false  }
-        ]}
+    return (<>
+        <Table headings={headings}
             paging={<TablePagingControls
-                from={state.currentFrom + 1}
-                to={state.currentTo + 1}
+                from={state.from + 1}
+                to={state.to}
                 dataLength={subscribers.length}
-                perPage={state.currentPerPage}
-                page={state.currentPage}
-                maxPage={Math.ceil(subscribers.length / state.currentPerPage)}
-                onPageChange={(page: number) => dispatch({ type: "SET_PAGE", payload: page })}
-                onPerPageChange={(perPage: number) => dispatch({ type: "SET_PER_PAGE", payload: perPage })}
+                perPage={state.perPage}
+                onPageChange={changePage}
+                onPerPageChange={changePerPage}
             />}
         >
-            {state.data.map((subscriber: any, index: number) =>
+            {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
                 <TableBodyRow
                     key={subscriber.subscription_id}>
                         {flow(
@@ -164,49 +77,24 @@ export const WithPaging = () => {
                 </TableBodyRow>)}
         </Table>
 
-    </React.Fragment>)
+    </>)
 };
 
 export const WithClickableRows = () => {
-    const [state, dispatch] = React.useReducer(reducer, initialState);
+    const [ state, { changePage, changePerPage } ] = useTableState({ data: subscribers });
 
-    React.useEffect(() => {
-        dispatch({ type: "SET_DATA", payload: { data: state.sortedData.slice(state.currentFrom, state.currentTo+1) } })
-    }, [ state.currentFrom, state.currentTo, state.sortedData ])
-
-    return (<React.Fragment>
-        <Table headings={[
-            { id: "formal_name",
-              label: "Navn",
-              rightAligned: false  },
-            { id: "subscription_id",
-              label: "Telefonnummer",
-              rightAligned: true  },
-            { id: "account_id",
-              label: "Avdelingsnummer",
-              rightAligned: true  },
-            { id: "account_name",
-              label: "Avdeling",
-              rightAligned: false  },
-            { id: "resource_type",
-              label: "Enhetstype",
-              rightAligned: false  },
-            { id: "subscription_type",
-              label: "Abonnement",
-              rightAligned: false  }
-        ]}
+    return (<>
+        <Table headings={headings}
             paging={<TablePagingControls
-                from={state.currentFrom + 1}
-                to={state.currentTo + 1}
+                from={state.from + 1}
+                to={state.to}
                 dataLength={subscribers.length}
-                perPage={state.currentPerPage}
-                page={state.currentPage}
-                maxPage={Math.ceil(subscribers.length / state.currentPerPage)}
-                onPageChange={(page: number) => dispatch({ type: "SET_PAGE", payload: page })}
-                onPerPageChange={(perPage: number) => dispatch({ type: "SET_PER_PAGE", payload: perPage })}
+                perPage={state.perPage}
+                onPageChange={changePage}
+                onPerPageChange={changePerPage}
             />}
         >
-            {state.data.map((subscriber: any, index: number) =>
+            {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
                 <TableBodyRow
                     onClickRow={() => console.log("You clicked row", index)}
                     key={subscriber.subscription_id}>
@@ -218,49 +106,24 @@ export const WithClickableRows = () => {
                 </TableBodyRow>)}
         </Table>
 
-    </React.Fragment>)
+    </>)
 };
 
 export const WithClickableRowsAndCells = () => {
-    const [state, dispatch] = React.useReducer(reducer, initialState);
+    const [ state, { changePage, changePerPage } ] = useTableState({ data: subscribers });
 
-    React.useEffect(() => {
-        dispatch({ type: "SET_DATA", payload: { data: state.sortedData.slice(state.currentFrom, state.currentTo+1) } })
-    }, [ state.currentFrom, state.currentTo, state.sortedData ])
-
-    return (<React.Fragment>
-        <Table headings={[
-            { id: "formal_name",
-              label: "Navn",
-              rightAligned: false  },
-            { id: "subscription_id",
-              label: "Telefonnummer",
-              rightAligned: true  },
-            { id: "account_id",
-              label: "Avdelingsnummer",
-              rightAligned: true  },
-            { id: "account_name",
-              label: "Avdeling",
-              rightAligned: false  },
-            { id: "resource_type",
-              label: "Enhetstype",
-              rightAligned: false  },
-            { id: "subscription_type",
-              label: "Abonnement",
-              rightAligned: false  }
-        ]}
+    return (<>
+        <Table headings={headings}
             paging={<TablePagingControls
-                from={state.currentFrom + 1}
-                to={state.currentTo + 1}
+                from={state.from + 1}
+                to={state.to}
                 dataLength={subscribers.length}
-                perPage={state.currentPerPage}
-                page={state.currentPage}
-                maxPage={Math.ceil(subscribers.length / state.currentPerPage)}
-                onPageChange={(page: number) => dispatch({ type: "SET_PAGE", payload: page })}
-                onPerPageChange={(perPage: number) => dispatch({ type: "SET_PER_PAGE", payload: perPage })}
+                perPage={state.perPage}
+                onPageChange={changePage}
+                onPerPageChange={changePerPage}
             />}
         >
-            {state.data.map((subscriber: any, index: number) =>
+            {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
                 <TableBodyRow
                     onClickRow={() => console.log("You clicked row", index)}
                     key={subscriber.subscription_id}>
@@ -272,58 +135,33 @@ export const WithClickableRowsAndCells = () => {
                 </TableBodyRow>)}
         </Table>
 
-    </React.Fragment>)
+    </>)
 };
 
 export const Selectable = () => {
-    const [state, dispatch] = React.useReducer(reducer, initialState);
+    const [ state, { changePage, changePerPage, toggleAll, toggleRow } ] = useTableState({ data: subscribers, paging: true, selecting: true, selectionId: 'subscription_id' });
 
-    React.useEffect(() => {
-        dispatch({ type: "SET_DATA", payload: { data: state.sortedData.slice(state.currentFrom, state.currentTo+1) } })
-    }, [ state.currentFrom, state.currentTo, state.sortedData ])
+    return (<>
+        <Table headings={headings}
 
-    return (<React.Fragment>
-        <Table headings={[
-            { id: "formal_name",
-              label: "Navn",
-              rightAligned: false  },
-            { id: "subscription_id",
-              label: "Telefonnummer",
-              rightAligned: true  },
-            { id: "account_id",
-              label: "Avdelingsnummer",
-              rightAligned: true  },
-            { id: "account_name",
-              label: "Avdeling",
-              rightAligned: false  },
-            { id: "resource_type",
-              label: "Enhetstype",
-              rightAligned: false  },
-            { id: "subscription_type",
-              label: "Abonnement",
-              rightAligned: false  }
-        ]}
-
-            onSelectAll={() => state.allSelected ? dispatch({ type: "DESELECT_ALL", payload: {} }) : dispatch({ type: "SELECT_ALL", payload: {} })}
+            onSelectAll={toggleAll}
             allSelected={state.allSelected}
-            selected={state.selected}
+            selected={state.selectedRows}
             paging={<TablePagingControls
-                from={state.currentFrom + 1}
-                to={state.currentTo + 1}
+                from={state.from + 1}
+                to={state.to}
                 dataLength={subscribers.length}
-                perPage={state.currentPerPage}
-                page={state.currentPage}
-                maxPage={Math.ceil(subscribers.length / state.currentPerPage)}
-                onPageChange={(page: number) => dispatch({ type: "SET_PAGE", payload: page })}
-                onPerPageChange={(perPage: number) => dispatch({ type: "SET_PER_PAGE", payload: perPage })}
+                perPage={state.perPage}
+                onPageChange={changePage}
+                onPerPageChange={changePerPage}
             />}
         >
-            {state.data.map((subscriber: any, index: number) =>
+            {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
                 <TableBodyRow
                     selectId={subscriber.subscription_id}
                     key={subscriber.subscription_id}
-                    onSelect={() => state.selected.includes(subscriber.subscription_id) ? dispatch({ type: "UNSELECT_ROW", payload: subscriber.subscription_id }) : dispatch({ type: "SELECT_ROW", payload: subscriber.subscription_id })}
-                    selected={state.selected.includes(subscriber.subscription_id)}>
+                    onSelect={() => toggleRow(subscriber.subscription_id)}
+                    selected={state.selectedRows.includes(subscriber.subscription_id)}>
                         {flow(
                             pick([ "formal_name", "subscription_id", "account_id", "account_name", "resource_type", "subscription_type" ]),
                             map((field: any) =>
@@ -332,57 +170,27 @@ export const Selectable = () => {
                 </TableBodyRow>)}
         </Table>
 
-    </React.Fragment>)
+    </>)
 };
 
 export const Sortable = () => {
-    const [state, dispatch] = React.useReducer(reducer, initialState);
+    const [ state, { changeSorting, changePage, changePerPage } ] = useTableState({ data: subscribers, paging: true, sorting: true, sortColumn: 'subscription_id' });
 
-    React.useEffect(() => {
-        const newData = state.sortDirection === "ASC" ? _.sortBy(subscribers, state.sortKey) : _.sortBy(subscribers, state.sortKey).reverse();
-        dispatch({ type: "SET_SORTED_DATA", payload: newData });
-    }, [ state.sortKey, state.sortDirection ]);
-
-    React.useEffect(() => {
-        dispatch({ type: "SET_DATA", payload: { data: state.sortedData.slice(state.currentFrom, state.currentTo+1) } })
-    }, [ state.currentFrom, state.currentTo, state.sortedData ])
-
-    return (<React.Fragment>
-        <Table headings={[
-            { id: "formal_name",
-              label: "Navn",
-              rightAligned: false  },
-            { id: "subscription_id",
-              label: "Telefonnummer",
-              rightAligned: true  },
-            { id: "account_id",
-              label: "Avdelingsnummer",
-              rightAligned: true  },
-            { id: "account_name",
-              label: "Avdeling",
-              rightAligned: false  },
-            { id: "resource_type",
-              label: "Enhetstype",
-              rightAligned: false  },
-            { id: "subscription_type",
-              label: "Abonnement",
-              rightAligned: false  }
-        ]}
-            sortedColumnId={state.sortKey}
+    return (<>
+        <Table headings={headings}
+            sortedColumnId={state.sortColumn}
             sortedColumnDirection={state.sortDirection}
-            onClickColumnHeader={(sortId) => dispatch({ type: "SORT_COLUMN", payload: sortId })}
+            onClickColumnHeader={(sortId) => changeSorting(sortId)}
             paging={<TablePagingControls
-                from={state.currentFrom + 1}
-                to={state.currentTo + 1}
+                from={state.from + 1}
+                to={state.to}
                 dataLength={subscribers.length}
-                perPage={state.currentPerPage}
-                page={state.currentPage}
-                maxPage={Math.ceil(subscribers.length / state.currentPerPage)}
-                onPageChange={(page: number) => dispatch({ type: "SET_PAGE", payload: page })}
-                onPerPageChange={(perPage: number) => dispatch({ type: "SET_PER_PAGE", payload: perPage })}
+                perPage={state.perPage}
+                onPageChange={changePage}
+                onPerPageChange={changePerPage}
             />}
         >
-            {state.data.map((subscriber: any, index: number) =>
+            {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
                 <TableBodyRow
                     key={subscriber.subscription_id}>
                         {flow(
@@ -393,66 +201,36 @@ export const Sortable = () => {
                 </TableBodyRow>)}
         </Table>
 
-    </React.Fragment>)
+    </>)
 };
 
 export const SortableAndSelectable = () => {
-    const [state, dispatch] = React.useReducer(reducer, initialState);
+    const [ state, { changeSorting, changePage, changePerPage, toggleAll, toggleRow } ] = useTableState({ data: subscribers, paging: true, selecting: true, selectionId: 'subscription_id', sorting: true, sortColumn: 'subscription_id' });
 
-    React.useEffect(() => {
-        const newData = state.sortDirection === "ASC" ? _.sortBy(subscribers, state.sortKey) : _.sortBy(subscribers, state.sortKey).reverse();
-        dispatch({ type: "SET_SORTED_DATA", payload: newData });
-    }, [ state.sortKey, state.sortDirection ]);
-
-    React.useEffect(() => {
-        dispatch({ type: "SET_DATA", payload: { data: state.sortedData.slice(state.currentFrom, state.currentTo+1) } })
-    }, [ state.currentFrom, state.currentTo, state.sortedData ])
-
-    return (<React.Fragment>
-        <Table headings={[
-            { id: "formal_name",
-              label: "Navn",
-              rightAligned: false  },
-            { id: "subscription_id",
-              label: "Telefonnummer",
-              rightAligned: true  },
-            { id: "account_id",
-              label: "Avdelingsnummer",
-              rightAligned: true  },
-            { id: "account_name",
-              label: "Avdeling",
-              rightAligned: false  },
-            { id: "resource_type",
-              label: "Enhetstype",
-              rightAligned: false  },
-            { id: "subscription_type",
-              label: "Abonnement",
-              rightAligned: false  }
-        ]}
-
-            onSelectAll={() => state.allSelected ? dispatch({ type: "DESELECT_ALL", payload: {} }) : dispatch({ type: "SELECT_ALL", payload: {} })}
+    return (<>
+        <Table headings={headings}
+            onSelectAll={toggleAll}
             allSelected={state.allSelected}
-            selected={state.selected}
-            sortedColumnId={state.sortKey}
+            selected={state.selectedRows}
+            sortedColumnId={state.sortColumn}
             sortedColumnDirection={state.sortDirection}
-            onClickColumnHeader={(sortId) => dispatch({ type: "SORT_COLUMN", payload: sortId })}
+            onClickColumnHeader={(sortId) => changeSorting(sortId)}
             paging={<TablePagingControls
-                from={state.currentFrom + 1}
-                to={state.currentTo + 1}
+                from={state.from + 1}
+                to={state.to}
                 dataLength={subscribers.length}
-                perPage={state.currentPerPage}
-                page={state.currentPage}
-                maxPage={Math.ceil(subscribers.length / state.currentPerPage)}
-                onPageChange={(page: number) => dispatch({ type: "SET_PAGE", payload: page })}
-                onPerPageChange={(perPage: number) => dispatch({ type: "SET_PER_PAGE", payload: perPage })}
+                perPage={state.perPage}
+                onPageChange={changePage}
+                onPerPageChange={changePerPage}
+                amountOfSelectedRows={state.selectedRows.length}
             />}
         >
-            {state.data.map((subscriber: any, index: number) =>
+            {state.data.slice(state.from, state.to).map((subscriber: any, index: number) =>
                 <TableBodyRow
                     selectId={subscriber.subscription_id}
                     key={subscriber.subscription_id}
-                    onSelect={() => state.selected.includes(subscriber.subscription_id) ? dispatch({ type: "UNSELECT_ROW", payload: subscriber.subscription_id }) : dispatch({ type: "SELECT_ROW", payload: subscriber.subscription_id })}
-                    selected={state.selected.includes(subscriber.subscription_id)}>
+                    onSelect={() => toggleRow(subscriber.subscription_id)}
+                    selected={state.selectedRows.includes(subscriber.subscription_id)}>
                         {flow(
                             pick([ "formal_name", "subscription_id", "account_id", "account_name", "resource_type", "subscription_type" ]),
                             map((field: any) =>
@@ -461,5 +239,5 @@ export const SortableAndSelectable = () => {
                 </TableBodyRow>)}
         </Table>
 
-    </React.Fragment>)
+    </>)
 };

--- a/component-lib/src/business/Table/Table.tsx
+++ b/component-lib/src/business/Table/Table.tsx
@@ -240,25 +240,25 @@ type TablePagingControlsProps = {
   to: number;
   perPage: number;
   dataLength: number;
-  amountOfSelectedRows?: number;
-  selectedRowsString?: string
+  numberOfSelectedRows?: number;
+  selectedRowsLabel?: string
 
   onPerPageChange: (perPage: number, e?: React.ChangeEvent<HTMLSelectElement>) => void;
   onPageChange: (forward: boolean, e?: React.MouseEvent<HTMLButtonElement>) => void;
 
-  fromToString?: string;
-  perPageString?: string;
+  fromToLabel?: string;
+  perPageLabel?: string;
   selectOptions?: Array<number>;
 };
 
 export const TablePagingControls: React.FC<TablePagingControlsProps> = props => {
   return (
     <form onSubmit={e => e.preventDefault()} className="table-paging">
-        {props.amountOfSelectedRows ? <span className="table-paging__text">
-            {`${props.amountOfSelectedRows} ${props.selectedRowsString || "rader er valgt"}`}
+        {props.numberOfSelectedRows ? <span className="table-paging__text">
+            {`${props.numberOfSelectedRows} ${props.selectedRowsLabel || "rader er valgt"}`}
         </span> : null}
       <label className="table-paging__text">
-        {props.perPageString || 'Rader per side: '}
+        {props.perPageLabel || 'Rader per side: '}
         <select
           value={props.perPage}
           onChange={e => props.onPerPageChange(parseInt(e.target.value), e)}
@@ -272,7 +272,7 @@ export const TablePagingControls: React.FC<TablePagingControlsProps> = props => 
         </select>
       </label>
       <span className="table-paging__text">
-        {props.fromToString || `${props.from}-${props.to} av ${props.dataLength}`}
+        {props.fromToLabel || `${props.from}-${props.to} av ${props.dataLength}`}
       </span>
       <button
         disabled={props.from === 1}

--- a/component-lib/src/business/Table/Table.tsx
+++ b/component-lib/src/business/Table/Table.tsx
@@ -240,11 +240,11 @@ type TablePagingControlsProps = {
   to: number;
   perPage: number;
   dataLength: number;
-  page: number;
-  maxPage: number;
+  amountOfSelectedRows?: number;
+  selectedRowsString?: string
 
   onPerPageChange: (perPage: number, e?: React.ChangeEvent<HTMLSelectElement>) => void;
-  onPageChange: (page: number, e?: React.MouseEvent<HTMLButtonElement>) => void;
+  onPageChange: (forward: boolean, e?: React.MouseEvent<HTMLButtonElement>) => void;
 
   fromToString?: string;
   perPageString?: string;
@@ -254,6 +254,9 @@ type TablePagingControlsProps = {
 export const TablePagingControls: React.FC<TablePagingControlsProps> = props => {
   return (
     <form onSubmit={e => e.preventDefault()} className="table-paging">
+        {props.amountOfSelectedRows ? <span className="table-paging__text">
+            {`${props.amountOfSelectedRows} ${props.selectedRowsString || "rader er valgt"}`}
+        </span> : null}
       <label className="table-paging__text">
         {props.perPageString || 'Rader per side: '}
         <select
@@ -272,23 +275,23 @@ export const TablePagingControls: React.FC<TablePagingControlsProps> = props => 
         {props.fromToString || `${props.from}-${props.to} av ${props.dataLength}`}
       </span>
       <button
-        disabled={props.page === 1}
+        disabled={props.from === 1}
         aria-label="Forrige side"
         className="table-paging__button"
         onClick={e => {
           e.preventDefault();
-          props.onPageChange(props.page - 1, e);
+          props.onPageChange(false, e);
         }}
       >
         <Icon icon="arrow-left" className="data-table__icon" />
       </button>
       <button
-        disabled={props.page === props.maxPage}
+        disabled={props.to === props.dataLength}
         aria-label="Neste side"
         className="table-paging__button"
         onClick={e => {
           e.preventDefault();
-          props.onPageChange(props.page + 1, e);
+          props.onPageChange(true, e);
         }}
       >
         <Icon icon="arrow-right" className="data-table__icon" />

--- a/component-lib/src/business/Table/index.ts
+++ b/component-lib/src/business/Table/index.ts
@@ -1,2 +1,2 @@
 export { Table, TableBodyCell, TableBodyRow, TableHeadCell, TablePagingControls } from './Table';
-export { useTableState } from './tableHooks';
+export { useTableState } from './useTableState';

--- a/component-lib/src/business/Table/index.ts
+++ b/component-lib/src/business/Table/index.ts
@@ -1,1 +1,2 @@
 export { Table, TableBodyCell, TableBodyRow, TableHeadCell, TablePagingControls } from './Table';
+export { useTableState } from './tableHooks';

--- a/component-lib/src/business/Table/tableHooks.ts
+++ b/component-lib/src/business/Table/tableHooks.ts
@@ -1,0 +1,185 @@
+import { useReducer, useEffect } from 'react';
+import _ from 'lodash';
+
+type sortDirectionType = 'ASC' | 'DESC' | 'NONE';
+
+interface TableState {
+    data: Array<any>,
+    sortColumn: string | number,
+    sortDirection: sortDirectionType,
+    perPage: number,
+    from: number,
+    to: number,
+    selectedRows: Array<string | number>,
+    allSelected: boolean,
+    selectionId: string | number,
+    selecting: boolean,
+    sorting: boolean,
+    paging: boolean
+}
+
+type changeSortingAction = (sortColumn: string | number) => void;
+type changePageAction = (forward: boolean) => void;
+type changePerPageAction = (perPage: number) => void;
+type toggleRowAction = (rowId: string | number) => void;
+type toggleAllAction = () => void;
+
+type tableStateAction = {
+    type: 'CHANGE_PAGE',
+    forward: boolean
+} | {
+    type: 'CHANGE_PER_PAGE',
+    perPage: number
+} | {
+    type: 'SORT_COLUMN',
+    sortColumn: string | number
+} | {
+    type: 'SET_DATA',
+    data: Array<any>
+} | {
+    type: 'SELECT_ROW' | 'DESELECT_ROW',
+    id: string | number
+} | {
+    type: 'SELECT_ALL' | 'DESELECT_ALL'
+}
+
+type TableStateHookType = [
+    TableState,
+    {
+        changeSorting: changeSortingAction,
+        changePage: changePageAction,
+        changePerPage: changePerPageAction,
+        toggleRow: toggleRowAction,
+        toggleAll: toggleAllAction,
+        dispatch: React.Dispatch<tableStateAction>
+    }
+]
+
+const sortedTableData = (data: Array<any>, sortColumn: string | number, sortDirection: sortDirectionType) => sortDirection === "ASC" ? _.sortBy(data, sortColumn) : _.sortBy(data, sortColumn).reverse();
+const newSortDirection = (oldSortColumn: string | number, newSortColumn: string | number, oldSortDirection: sortDirectionType) => (newSortColumn === oldSortColumn && oldSortDirection === "ASC") ? "DESC" : "ASC";
+const newTo = (currentFrom: number, perPage: number, dataLength: number) => currentFrom + perPage > dataLength ? dataLength : currentFrom + perPage;
+const newFrom = (currentFrom: number, forward: boolean, perPage: number, dataLength: number) => {
+    const diff = forward ? perPage : perPage * -1;
+    return currentFrom + diff > dataLength ? dataLength : currentFrom + diff < 0 ? 0 : currentFrom + diff;
+}
+const maybePagedData = ({ data, paging, from, to }: TableState) => paging ? data.slice(from, to) : data;
+
+function tableReducer(state: TableState, action: tableStateAction): TableState {
+    switch (action.type) {
+        case "CHANGE_PAGE":
+            return _.cloneDeep({
+                ...state,
+                from: newFrom(state.from, action.forward, state.perPage, state.data.length),
+                to: newTo(newFrom(state.from, action.forward, state.perPage, state.data.length), state.perPage, state.data.length),
+                allSelected: false
+            });
+        case "CHANGE_PER_PAGE":
+            return _.cloneDeep({
+                ...state,
+                to: newTo(state.from, action.perPage, state.data.length),
+                perPage: action.perPage,
+                allSelected: false
+            });
+        case "SORT_COLUMN":
+            return _.cloneDeep({
+                ...state,
+                data: sortedTableData(state.data, action.sortColumn, newSortDirection(state.sortColumn, action.sortColumn, state.sortDirection)),
+                sortColumn: action.sortColumn,
+                sortDirection: newSortDirection(state.sortColumn, action.sortColumn, state.sortDirection),
+                allSelected: false
+            });
+        case "SET_DATA":
+            return _.cloneDeep({
+                ...state,
+                data: sortedTableData(action.data, state.sortColumn, state.sortDirection),
+                from: 0,
+                to: newTo(0, state.perPage, action.data.length),
+                selectedRows: [],
+                allSelected: false
+            });
+        case "SELECT_ALL":
+            return _.cloneDeep({
+                ...state,
+                selectedRows: maybePagedData(state).map((val) => val[state.selectionId]),
+                allSelected: true
+            });
+        case "DESELECT_ALL":
+            return _.cloneDeep({
+                ...state,
+                selectedRows: [],
+                allSelected: false
+            });
+        case "SELECT_ROW":
+            return _.cloneDeep({
+                ...state,
+                selectedRows: [...state.selectedRows, action.id],
+                allSelected: maybePagedData(state).reduce((acc, sub) => acc && [...state.selectedRows, action.id].includes(sub[state.selectionId]), true)
+            });
+
+        case "DESELECT_ROW":
+            return _.cloneDeep({
+                ...state,
+                selectedRows: _.without(state.selectedRows, action.id),
+                allSelected: false
+            });
+        default: return state;
+    }
+}
+
+type TableStateArgs = {
+    data: Array<any>,
+} & (
+        | {
+            sorting: true,
+            sortColumn: string | number,
+            sortDirection?: sortDirectionType
+        } | {
+        }
+    ) & (
+        | {
+            paging: true,
+            perPage?: number,
+            from?: number,
+            to?: number
+        } | {
+        }
+    ) & (
+        | {
+            selecting: true,
+            selectionId: string | number,
+            allSelected?: boolean,
+            selectedRows?: Array<string | number>
+        } | {
+        }
+    )
+
+export function useTableState(args: TableStateArgs): TableStateHookType {
+    const initialState: TableState = {
+        sorting: 'sorting' in args && args.sorting,
+        data: 'sorting' in args ? sortedTableData(args.data, args.sortColumn, args.sortDirection || "ASC") : args.data,
+        sortColumn: 'sorting' in args ? args.sortColumn : '',
+        sortDirection: 'sorting' in args && args.sortDirection ? args.sortDirection : 'ASC',
+        paging: 'paging' in args && args.paging,
+        perPage: 'paging' in args && args.perPage ? args.perPage : 10,
+        from: 'paging' in args && args.from ? args.from : 0,
+        to: 'paging' in args && args.to ? args.to : newTo(0, 'perPage' in args && args.perPage ? args.perPage : 10, args.data.length),
+        selecting: 'selecting' in args && args.selecting,
+        selectedRows: 'selecting' in args && args.selectedRows ? args.selectedRows : [],
+        allSelected: 'selecting' in args && args.allSelected ? args.allSelected : false,
+        selectionId: 'selecting' in args ? args.selectionId : '',
+    }
+
+    const [state, dispatch] = useReducer(tableReducer, initialState);
+
+    useEffect(() => {
+        dispatch({ type: "SET_DATA", data: args.data });
+    }, [args.data])
+
+    const changeSorting: changeSortingAction = (sortColumn) => dispatch({ type: "SORT_COLUMN", sortColumn });
+    const changePage: changePageAction = (forward) => dispatch({ type: "CHANGE_PAGE", forward });
+    const changePerPage: changePerPageAction = (perPage) => dispatch({ type: "CHANGE_PER_PAGE", perPage });
+    const toggleRow: toggleRowAction = (id) => dispatch({ type: state.selectedRows.includes(id) ? 'DESELECT_ROW' : 'SELECT_ROW', id });
+    const toggleAll: toggleAllAction = () => dispatch({ type: state.allSelected ? 'DESELECT_ALL' : 'SELECT_ALL' });
+
+    return [state, { changeSorting, changePage, changePerPage, toggleRow, toggleAll, dispatch }];
+}

--- a/component-lib/src/business/Table/useTableState.ts
+++ b/component-lib/src/business/Table/useTableState.ts
@@ -18,11 +18,11 @@ interface TableState {
     paging: boolean
 }
 
-type changeSortingAction = (sortColumn: string | number) => void;
-type changePageAction = (forward: boolean) => void;
-type changePerPageAction = (perPage: number) => void;
-type toggleRowAction = (rowId: string | number) => void;
-type toggleAllAction = () => void;
+type setSortingAction = (sortColumn: string | number) => void;
+type setPageAction = (forward: boolean) => void;
+type setPerPageAction = (perPage: number) => void;
+type setSelectRowAction = (rowId: string | number) => void;
+type setSelectAllAction = () => void;
 
 type tableStateAction = {
     type: 'CHANGE_PAGE',
@@ -46,11 +46,11 @@ type tableStateAction = {
 type TableStateHookType = [
     TableState,
     {
-        changeSorting: changeSortingAction,
-        changePage: changePageAction,
-        changePerPage: changePerPageAction,
-        toggleRow: toggleRowAction,
-        toggleAll: toggleAllAction,
+        setSorting: setSortingAction,
+        setPage: setPageAction,
+        setPerPage: setPerPageAction,
+        setSelectRow: setSelectRowAction,
+        setSelectAll: setSelectAllAction,
         dispatch: React.Dispatch<tableStateAction>
     }
 ]
@@ -175,11 +175,11 @@ export function useTableState(args: TableStateArgs): TableStateHookType {
         dispatch({ type: "SET_DATA", data: args.data });
     }, [args.data])
 
-    const changeSorting: changeSortingAction = (sortColumn) => dispatch({ type: "SORT_COLUMN", sortColumn });
-    const changePage: changePageAction = (forward) => dispatch({ type: "CHANGE_PAGE", forward });
-    const changePerPage: changePerPageAction = (perPage) => dispatch({ type: "CHANGE_PER_PAGE", perPage });
-    const toggleRow: toggleRowAction = (id) => dispatch({ type: state.selectedRows.includes(id) ? 'DESELECT_ROW' : 'SELECT_ROW', id });
-    const toggleAll: toggleAllAction = () => dispatch({ type: state.allSelected ? 'DESELECT_ALL' : 'SELECT_ALL' });
+    const setSorting: setSortingAction = (sortColumn) => dispatch({ type: "SORT_COLUMN", sortColumn });
+    const setPage: setPageAction = (forward) => dispatch({ type: "CHANGE_PAGE", forward });
+    const setPerPage: setPerPageAction = (perPage) => dispatch({ type: "CHANGE_PER_PAGE", perPage });
+    const setSelectRow: setSelectRowAction = (id) => dispatch({ type: state.selectedRows.includes(id) ? 'DESELECT_ROW' : 'SELECT_ROW', id });
+    const setSelectAll: setSelectAllAction = () => dispatch({ type: state.allSelected ? 'DESELECT_ALL' : 'SELECT_ALL' });
 
-    return [state, { changeSorting, changePage, changePerPage, toggleRow, toggleAll, dispatch }];
+    return [state, { setSorting, setPage, setPerPage, setSelectRow, setSelectAll, dispatch }];
 }


### PR DESCRIPTION
Adds a custom hook for table state that can be used, also fixes paging to no longer be dependent on a page number, but only from/to props. So that, if you see from 11-20 and switch to 25 per page, you no longer jump to see from 26-50, but instead see 11-36.