### PR TITLE
Updated imports to avoid circular dependencies in the component lib

### DIFF
--- a/component-lib/src/atoms/Button/Button.tsx
+++ b/component-lib/src/atoms/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { ButtonHTMLAttributes, AnchorHTMLAttributes, CSSProperties } from 'react';
 import classnames from 'classnames';
-import { Icon, IconDefinition } from '../../index';
+import { Icon, IconDefinition } from '../../atoms/Icon/index';
 
 export type ButtonKind = 'normal' | 'primary' | 'cancel' | 'link' | 'inverted' | 'negative';
 export type ButtonType = 'button' | 'reset' | 'submit';

--- a/component-lib/src/atoms/Link/Link.tsx
+++ b/component-lib/src/atoms/Link/Link.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import cs from 'classnames';
-import { Icon, IconDefinition } from '../../index';
+import { Icon, IconDefinition } from '../../atoms/Icon/index';
 
 /**
  * Status: *finished*.
@@ -104,7 +104,7 @@ export const Link = (props: LinkProps) => {
       >
         <div className="bubble-link--flex-container">
           <span
-            className={`bubble-link--icon-circle 
+            className={`bubble-link--icon-circle
               bubble-link--circle-background--${iconColor}${
               inverted ? '-inverted' : ''
             }`}

--- a/component-lib/src/molecules/InfoBox/InfoBox.jsx
+++ b/component-lib/src/molecules/InfoBox/InfoBox.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Heading, colors } from '../../index';
+import Heading from '../../atoms/Heading/Heading';
+import { colors } from '../../utils/colors';
 
 /**
  * Status: *finished*.

--- a/component-lib/src/molecules/LightAlert/LightAlert.jsx
+++ b/component-lib/src/molecules/LightAlert/LightAlert.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { Icon, Heading, colors } from '../../index';
+import { Icon } from '../../atoms/Icon/index';
+import Heading from '../../atoms/Heading/Heading';
+import { colors } from '../../utils/colors';
 
 /**
  * Status: *in progress*.


### PR DESCRIPTION
The problem seemed to be the Button implementation imported the whole component-lib through `import ... from '../../index';`, causing a circular dependency when ModalDialog tried to import Button.kinds (before the Button definition itself had been completed).

I've updated the imports (including a couple others I found) to import specifically the components the source files need.