### PR TITLE
SubscriptionAccordion - pass buttonText as null to not render button …

### DIFF
--- a/component-lib/src/molecules/SubscriptionAccordion/SubscriptionAccordion.d.ts
+++ b/component-lib/src/molecules/SubscriptionAccordion/SubscriptionAccordion.d.ts
@@ -26,6 +26,7 @@ export interface SubscriptionAccordionProps {
   disclaimers?: any;
   scrollToOnOpen?: boolean;
   className?: string;
+  buttonText?: any;
   onOpen?: (...args: any[]) => any;
   onSelect?: (...args: any[]) => any;
 }

--- a/component-lib/src/molecules/SubscriptionAccordion/SubscriptionAccordion.jsx
+++ b/component-lib/src/molecules/SubscriptionAccordion/SubscriptionAccordion.jsx
@@ -76,14 +76,16 @@ const SubscriptionAccordion = ({
             </>
           )}
           {children}
-          <Button
-            kind="primary"
-            className="subscription-accordion__button-choose"
-            text={buttonText}
-            size="small"
-            margin="top"
-            onClick={() => onSelect(id)}
-          />
+          {buttonText && (
+            <Button
+              kind="primary"
+              className="subscription-accordion__button-choose"
+              text={buttonText}
+              size="small"
+              margin="top"
+              onClick={() => onSelect(id)}
+            />
+          )}
           <div className="subscription-accordion__disclaimers">{disclaimers}</div>
         </section>
       )}


### PR DESCRIPTION
Telia.no - CMS, usually builds up all "main body" text (text, paragraphs, buttons, links, whatever...) for the accordion body.

- As editors needs to copy paste url's where the "button" should go to as they are simple href's in the CMS