### PR TITLE
declare className prop in all FullWidthTable components

### DIFF
--- a/src/atoms/FullWidthTable/FullWidthTable.d.ts
+++ b/src/atoms/FullWidthTable/FullWidthTable.d.ts
@@ -1,29 +1,27 @@
 import * as React from 'react';
 import { UseThSortable } from './useThSortable';
 
-declare type CommonProps = React.HTMLAttributes<HTMLElement>;
-
-declare type FullWidthTableProps = CommonProps & {
+declare type FullWidthTableProps = React.HTMLAttributes<HTMLTableElement> & {
   clickable?: boolean;
 };
 
-declare type ThSortableProps = CommonProps & {
+declare type ThSortableProps = React.HTMLAttributes<HTMLTableHeaderCellElement> & {
   onSort: () => void;
   isSorted?: boolean;
   isSortedDesc?: boolean;
   sortPriority?: number;
 };
 
-declare type TFootProps = CommonProps & {
+declare type TFootProps = React.HTMLAttributes<HTMLTableSectionElement> & {
   white?: boolean;
 };
 
 declare const FullWidthTable: React.FC<FullWidthTableProps> & {
-  THead: React.FC<CommonProps>;
-  TBody: React.FC<CommonProps>;
-  Th: React.FC<CommonProps>;
-  Tr: React.FC<CommonProps>;
-  Td: React.FC<CommonProps>;
+  THead: React.FC<React.HTMLAttributes<HTMLTableSectionElement>>;
+  TBody: React.FC<React.HTMLAttributes<HTMLTableSectionElement>>;
+  Th: React.FC<React.HTMLAttributes<HTMLTableHeaderCellElement>>;
+  Tr: React.FC<React.HTMLAttributes<HTMLTableRowElement>>;
+  Td: React.FC<React.HTMLAttributes<HTMLTableDataCellElement>>;
 
   ThSortable: React.FC<ThSortableProps>;
 

--- a/src/atoms/FullWidthTable/FullWidthTable.d.ts
+++ b/src/atoms/FullWidthTable/FullWidthTable.d.ts
@@ -1,34 +1,40 @@
 import * as React from 'react';
 import { UseThSortable } from './useThSortable';
+import { MouseEventHandler } from 'react';
 
-declare type FullWidthTableProps = {
+declare type CommonProps = {
+  className?: string;
+};
+
+declare type FullWidthTableProps = CommonProps & {
   clickable?: boolean;
 };
 
-declare type TrProps = {
-  onClick: () => void;
+declare type TrProps = CommonProps & {
+  onClick?: MouseEventHandler;
 };
 
-declare type ThSortableProps = {
+declare type ThSortableProps = CommonProps & {
+  onSort: () => void;
   isSorted?: boolean;
   isSortedDesc?: boolean;
   sortPriority?: number;
 };
 
-declare type TFootProps = {
+declare type TFootProps = CommonProps & {
   white?: boolean;
 };
 
-declare const FullWidthTable: React.FC<React.ReactNode | FullWidthTableProps> & {
-  THead: React.FC<React.ReactNode>;
-  TBody: React.FC<React.ReactNode>;
-  Th: React.FC<React.ReactNode>;
-  Tr: React.FC<React.ReactNode | TrProps>;
-  Td: React.FC<React.ReactNode>;
+declare const FullWidthTable: React.FC<FullWidthTableProps> & {
+  THead: React.FC<CommonProps>;
+  TBody: React.FC<CommonProps>;
+  Th: React.FC<CommonProps>;
+  Tr: React.FC<TrProps>;
+  Td: React.FC<CommonProps>;
 
-  ThSortable: React.FC<React.ReactNode | ThSortableProps>;
+  ThSortable: React.FC<ThSortableProps>;
 
-  TFoot: React.FC<React.ReactNode | TFootProps>;
+  TFoot: React.FC<TFootProps>;
 
   useThSortable: UseThSortable;
 };

--- a/src/atoms/FullWidthTable/FullWidthTable.d.ts
+++ b/src/atoms/FullWidthTable/FullWidthTable.d.ts
@@ -1,17 +1,10 @@
 import * as React from 'react';
 import { UseThSortable } from './useThSortable';
-import { MouseEventHandler } from 'react';
 
-declare type CommonProps = {
-  className?: string;
-};
+declare type CommonProps = React.HTMLAttributes<HTMLElement>;
 
 declare type FullWidthTableProps = CommonProps & {
   clickable?: boolean;
-};
-
-declare type TrProps = CommonProps & {
-  onClick?: MouseEventHandler;
 };
 
 declare type ThSortableProps = CommonProps & {
@@ -29,7 +22,7 @@ declare const FullWidthTable: React.FC<FullWidthTableProps> & {
   THead: React.FC<CommonProps>;
   TBody: React.FC<CommonProps>;
   Th: React.FC<CommonProps>;
-  Tr: React.FC<TrProps>;
+  Tr: React.FC<CommonProps>;
   Td: React.FC<CommonProps>;
 
   ThSortable: React.FC<ThSortableProps>;

--- a/src/atoms/FullWidthTable/FullWidthTable.jsx
+++ b/src/atoms/FullWidthTable/FullWidthTable.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import { useThSortable } from './useThSortable';
+import './FullWidthTable.stories.css';
 
 /**
  * Status: *finished*

--- a/src/atoms/FullWidthTable/FullWidthTable.jsx
+++ b/src/atoms/FullWidthTable/FullWidthTable.jsx
@@ -62,12 +62,11 @@ const TFoot = ({ children, white, className, ...rest }) => (
 );
 FullWidthTable.TFoot = TFoot;
 
-const Tr = ({ children, onClick, className, ...rest }) => (
+const Tr = ({ children, className, ...rest }) => (
   <tr
     className={classnames('full-width-table__row', {
       [className]: className,
     })}
-    onClick={onClick ? onClick : null}
     {...rest}
   >
     {children}

--- a/src/atoms/FullWidthTable/FullWidthTable.stories.css
+++ b/src/atoms/FullWidthTable/FullWidthTable.stories.css
@@ -1,5 +1,5 @@
 .purple {
-    color: var(--core-purple);
+    color: #990ae3;
 }
 
 .italic {

--- a/src/atoms/FullWidthTable/FullWidthTable.stories.pcss
+++ b/src/atoms/FullWidthTable/FullWidthTable.stories.pcss
@@ -1,0 +1,11 @@
+.purple {
+    color: var(--core-purple);
+}
+
+.italic {
+    font-style: italic;
+}
+
+.lineThrough {
+    text-decoration: line-through;
+}

--- a/src/atoms/FullWidthTable/FullWidthTable.stories.tsx
+++ b/src/atoms/FullWidthTable/FullWidthTable.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import FullWidthTable from './FullWidthTable';
-import { number } from '@storybook/addon-knobs';
+import { boolean, number, optionsKnob } from '@storybook/addon-knobs';
 
 export default {
   title: 'Component library/Atoms/FullWidth Table',
@@ -9,35 +9,45 @@ export default {
 
 export const Default = () => {
   const { THead, TBody, Th, Tr, Td } = FullWidthTable;
+  const column2classNames = optionsKnob(
+    'Column 2 classNames',
+    { Purple: 'purple', Italic: 'italic', LineThrough: 'lineThrough' },
+    '',
+    {
+      display: 'check',
+    }
+  )
+    .toString()
+    .replaceAll(',', ' ');
 
   return (
-    <FullWidthTable>
+    <FullWidthTable className={'no-ts-error'}>
       <THead>
         <Tr>
           <Th>Column 1</Th>
-          <Th>Column 2</Th>
+          <Th className={column2classNames}>Column 2</Th>
           <Th>Column 3</Th>
         </Tr>
       </THead>
       <TBody>
         <Tr>
           <Td>Nulla quis lorem ut libero malesuada feugiat</Td>
-          <Td>Lorem</Td>
+          <Td className={column2classNames}>Lorem</Td>
           <Td>Ipsum</Td>
         </Tr>
         <Tr>
           <Td>Lorem ipsum dolor sit amet</Td>
-          <Td>Consectetur</Td>
+          <Td className={column2classNames}>Consectetur</Td>
           <Td>Elit</Td>
         </Tr>
         <Tr>
           <Td>Donec ruTrum congue leo</Td>
-          <Td>Eget</Td>
+          <Td className={column2classNames}>Eget</Td>
           <Td>Malesuada</Td>
         </Tr>
         <Tr>
           <Td>Nulla quis lorem ut libero malesuada feugiat</Td>
-          <Td>Lorem</Td>
+          <Td className={column2classNames}>Lorem</Td>
           <Td>Ipsum</Td>
         </Tr>
         <Tr>
@@ -46,7 +56,7 @@ export const Default = () => {
               Lorem ipsum dolor sit amet
             </a>
           </Td>
-          <Td>Consectetur</Td>
+          <Td className={column2classNames}>Consectetur</Td>
           <Td>Elit</Td>
         </Tr>
         <Tr>
@@ -55,7 +65,7 @@ export const Default = () => {
               Donec ruTrum congue leo
             </a>
           </Td>
-          <Td>Eget</Td>
+          <Td className={column2classNames}>Eget</Td>
           <Td>Malesuada</Td>
         </Tr>
       </TBody>
@@ -110,8 +120,9 @@ export const SortedFullWidthTable = () => {
   );
 };
 
-export const WithFooter1 = () => {
+export const WithFooter = () => {
   const { THead, TBody, Th, Tr, Td, TFoot } = FullWidthTable;
+  const whiteFooter = boolean('White footer', false);
 
   return (
     <FullWidthTable>
@@ -122,7 +133,7 @@ export const WithFooter1 = () => {
           <Th>Pris</Th>
         </Tr>
       </THead>
-      <TFoot>
+      <TFoot white={whiteFooter}>
         <Tr>
           <Td>Sum</Td>
           <Td>Foo</Td>
@@ -144,37 +155,6 @@ export const WithFooter1 = () => {
           <Td>Bruk</Td>
           <Td>Foobar</Td>
           <Td>254,-</Td>
-        </Tr>
-      </TBody>
-    </FullWidthTable>
-  );
-};
-
-export const WithFooter2 = () => {
-  const { THead, TBody, Th, Tr, Td, TFoot } = FullWidthTable;
-
-  return (
-    <FullWidthTable>
-      <THead>
-        <Tr>
-          <Th>Kostnader</Th>
-          <Th>Pris</Th>
-        </Tr>
-      </THead>
-      <TFoot white>
-        <Tr>
-          <Td>Sum</Td>
-          <Td>299,-</Td>
-        </Tr>
-      </TFoot>
-      <TBody>
-        <Tr>
-          <Td>Fast avgifter</Td>
-          <Td>399,-</Td>
-        </Tr>
-        <Tr>
-          <Td>Rabatter</Td>
-          <Td>-100,-</Td>
         </Tr>
       </TBody>
     </FullWidthTable>

--- a/src/atoms/FullWidthTable/FullWidthTable.stories.tsx
+++ b/src/atoms/FullWidthTable/FullWidthTable.stories.tsx
@@ -21,7 +21,7 @@ export const Default = () => {
     .replaceAll(',', ' ');
 
   return (
-    <FullWidthTable id={'defaultFullWidthTable'} className={'no-ts-error'}>
+    <FullWidthTable id="defaultFullWidthTable" className="no-ts-error">
       <THead>
         <Tr>
           <Th>Column 1</Th>

--- a/src/atoms/FullWidthTable/FullWidthTable.stories.tsx
+++ b/src/atoms/FullWidthTable/FullWidthTable.stories.tsx
@@ -21,7 +21,7 @@ export const Default = () => {
     .replaceAll(',', ' ');
 
   return (
-    <FullWidthTable className={'no-ts-error'}>
+    <FullWidthTable id={'defaultFullWidthTable'} className={'no-ts-error'}>
       <THead>
         <Tr>
           <Th>Column 1</Th>


### PR DESCRIPTION
The className prop was not declared in the FullWidthTable components. This PR should fix it.
This changes might affect all sites. I hope it doesn't break anything. Please verify it works.

I also added some Storybook knobs for it (and the white footer, to reduce code)

