### PR TITLE
Add missing export statements

### DIFF
--- a/src/molecules/BigImageDialog/BigImageDialog.d.ts
+++ b/src/molecules/BigImageDialog/BigImageDialog.d.ts
@@ -11,6 +11,6 @@ export interface BigImageDialogProps {
   renderTo?: React.ReactNode;
 }
 
-const BigImageDialog: React.FC<BigImageDialogProps>;
+export const BigImageDialog: React.FC<BigImageDialogProps>;
 
 export default BigImageDialog;

--- a/src/molecules/BigImageDialog/BigImageDialog.d.ts
+++ b/src/molecules/BigImageDialog/BigImageDialog.d.ts
@@ -11,6 +11,6 @@ export interface BigImageDialogProps {
   renderTo?: React.ReactNode;
 }
 
-export const BigImageDialog: React.FC<BigImageDialogProps>;
+declare const BigImageDialog: React.FC<BigImageDialogProps>;
 
 export default BigImageDialog;

--- a/src/molecules/InfoCard/InfoCard.d.ts
+++ b/src/molecules/InfoCard/InfoCard.d.ts
@@ -6,6 +6,6 @@ export interface InfoCardProps {
   usps: string[];
 }
 
-const InfoCard: React.FC<InfoCardProps>;
+export const InfoCard: React.FC<InfoCardProps>;
 
 export default InfoCard;

--- a/src/molecules/InfoCard/InfoCard.d.ts
+++ b/src/molecules/InfoCard/InfoCard.d.ts
@@ -6,6 +6,6 @@ export interface InfoCardProps {
   usps: string[];
 }
 
-export const InfoCard: React.FC<InfoCardProps>;
+declare const InfoCard: React.FC<InfoCardProps>;
 
 export default InfoCard;

--- a/src/molecules/SubscriptionAccordion/SubscriptionAccordion.d.ts
+++ b/src/molecules/SubscriptionAccordion/SubscriptionAccordion.d.ts
@@ -31,6 +31,6 @@ export interface SubscriptionAccordionProps {
   description?: any;
 }
 
-const SubscriptionAccordion: React.FC<SubscriptionAccordionProps>;
+export const SubscriptionAccordion: React.FC<SubscriptionAccordionProps>;
 
 export default SubscriptionAccordion;

--- a/src/molecules/SubscriptionAccordion/SubscriptionAccordion.d.ts
+++ b/src/molecules/SubscriptionAccordion/SubscriptionAccordion.d.ts
@@ -31,6 +31,6 @@ export interface SubscriptionAccordionProps {
   description?: any;
 }
 
-export const SubscriptionAccordion: React.FC<SubscriptionAccordionProps>;
+declare const SubscriptionAccordion: React.FC<SubscriptionAccordionProps>;
 
 export default SubscriptionAccordion;

--- a/src/molecules/SubscriptionLinesAccordion/SubscriptionLinesAccordion.d.ts
+++ b/src/molecules/SubscriptionLinesAccordion/SubscriptionLinesAccordion.d.ts
@@ -35,6 +35,6 @@ export interface SubscriptionLinesAccordionProps {
   style?: React.CSSProperties;
 }
 
-export const SubscriptionLinesAccordion: React.FC<SubscriptionLinesAccordionProps>;
+declare const SubscriptionLinesAccordion: React.FC<SubscriptionLinesAccordionProps>;
 
 export default SubscriptionLinesAccordion;

--- a/src/molecules/SubscriptionLinesAccordion/SubscriptionLinesAccordion.d.ts
+++ b/src/molecules/SubscriptionLinesAccordion/SubscriptionLinesAccordion.d.ts
@@ -35,6 +35,6 @@ export interface SubscriptionLinesAccordionProps {
   style?: React.CSSProperties;
 }
 
-const SubscriptionLinesAccordion: React.FC<SubscriptionLinesAccordionProps>;
+export const SubscriptionLinesAccordion: React.FC<SubscriptionLinesAccordionProps>;
 
 export default SubscriptionLinesAccordion;


### PR DESCRIPTION
TS1046: 'declare' modifier required for top level element

We get this error when using the Styleguide in using  "typescript": "^3.8.3". 


![image](https://user-images.githubusercontent.com/430645/99537157-9a4fce80-29ab-11eb-920a-97f4a73c8131.png)
