### PR TITLE
Add extra margin on small device when discount

### DIFF
--- a/src/molecules/SubscriptionAccordion/SubscriptionAccordion.jsx
+++ b/src/molecules/SubscriptionAccordion/SubscriptionAccordion.jsx
@@ -36,7 +36,10 @@ const SubscriptionAccordion = ({
     <section
       ref={ref}
       id={id}
-      className={cn('subscription-accordion', className, { 'subscription-accordion__inverted': isInverted })}
+      className={cn('subscription-accordion', className, {
+        'subscription-accordion__inverted': isInverted,
+        'subscription-accordion__extra-margin': !!discount,
+      })}
     >
       <button
         className={cn('subscription-accordion__header', {
@@ -59,7 +62,7 @@ const SubscriptionAccordion = ({
         <div className="subscription-accordion__aside">
           <span className="subscription-accordion__price">{formatPrice(price)}</span>
           {priceInfo &&
-            priceInfo.map(info => (
+            priceInfo.map((info) => (
               <span key={info} className="subscription-accordion__price-info">
                 {info}
               </span>
@@ -89,7 +92,7 @@ const SubscriptionAccordion = ({
   );
 };
 
-const formatPrice = price => {
+const formatPrice = (price) => {
   if (typeof price === 'number') {
     return price % 1 === 0 ? price + ',-' : price + ' kr';
   }

--- a/src/molecules/SubscriptionAccordion/SubscriptionAccordion.pcss
+++ b/src/molecules/SubscriptionAccordion/SubscriptionAccordion.pcss
@@ -8,6 +8,14 @@
     box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.12);
     margin: 1rem 0;
 
+    &__extra-margin {
+        margin-top: 2rem;
+
+        @media all and (min-width: 37.5em) {
+            margin-top: 1rem;
+        }
+    }
+
     &__header {
         display: flex;
         align-items: center;

--- a/src/molecules/SubscriptionAccordion/SubscriptionAccordion.stories.tsx
+++ b/src/molecules/SubscriptionAccordion/SubscriptionAccordion.stories.tsx
@@ -269,6 +269,10 @@ export const SubscriptionAccordionsWithSelection = () => {
           iconName: 'infinite',
           name: 'Ubegrenset data med 10mbit/s hastighet etter 500GB',
         }}
+        discount={{
+          price: 1891,
+          description: 'i rabatt på tlf',
+        }}
         disclaimers={disclaimers}
         onOpen={() => {
           currentSubscription === 'smart500' ? setCurrentSubscription('') : setCurrentSubscription('smart500');
@@ -291,6 +295,10 @@ export const SubscriptionAccordionsWithSelection = () => {
         feature={{
           iconName: 'infinite',
           name: 'Ubegrenset data med 10mbit/s hastighet etter 500GB',
+        }}
+        discount={{
+          price: 1891,
+          description: 'i rabatt på tlf',
         }}
         disclaimers={disclaimers}
         onOpen={() => {


### PR DESCRIPTION
The discount overlapped a little the next subscription accordion. 
Adding a little more margin in this case to avoid that.