### PR TITLE
Fix time picker dropdown design across browsers

### DIFF
--- a/src/molecules/DatePicker/DatePickerTimeInput.tsx
+++ b/src/molecules/DatePicker/DatePickerTimeInput.tsx
@@ -28,17 +28,42 @@ export const DatePickerTimeInput = (props: Props) => {
     }
     return o;
   };
+
+  const setTime = (value: string, previousValue: string) => {
+    const changeWasRemove = value.length < previousValue.length;
+    const changeWasClearReplace = previousValue.length === 5 && value.length === 1;
+
+    const parts = value.split(':');
+
+    const h = parts?.[0];
+    const validHour = !h || h.length < 2 || ('0' <= h && h < '24' && h.length < 3);
+
+    const m = parts?.[1];
+    const validMin = !m || m.length < 2 || ('0' <= m && m < '60' && m.length < 3);
+
+    if (!validHour || !validMin) {
+      return;
+    }
+
+    const hString = h ? (parseInt(h) > 2 && parseInt(h) < 10 ? h.padStart(2, '0') : h) : '';
+    const mString = m ? (parseInt(m) > 5 && parseInt(m) < 10 ? m.padStart(2, '0') : m) : '';
+
+    if ((changeWasRemove && !changeWasClearReplace) || hString.length == 1 || mString.length == 1) {
+      return props.setTime(value);
+    } else {
+      return props.setTime(`${hString ? hString + ':' : ''}${mString ? mString : ''}`);
+    }
+  };
+
   return (
     <div className="telia-date-picker--input-wrapper">
       <Dropdown open={open} toggle={() => setOpen(!open)}>
         <DropdownSearchToggle
           className="telia-date-picker--input telia-date-picker--input__time"
-          type="time"
+          type="text"
           value={props.inputValue ?? '00:00'}
           size={props.size}
-          onInputChange={(value) => {
-            props.setTime?.(value);
-          }}
+          onInputChange={(value) => setTime(value, props.inputValue)}
           onFocus={() => setOpen(true)}
           rightContent={props.rightContent}
         />

--- a/src/molecules/DatePicker/DatePickerTimeInput.tsx
+++ b/src/molecules/DatePicker/DatePickerTimeInput.tsx
@@ -57,15 +57,16 @@ export const DatePickerTimeInput = (props: Props) => {
 
   return (
     <div className="telia-date-picker--input-wrapper">
-      <Dropdown open={open} toggle={() => setOpen(!open)}>
+      <Dropdown open={open} setOpen={setOpen}>
         <DropdownSearchToggle
           className="telia-date-picker--input telia-date-picker--input__time"
           type="text"
+          label={!props.inputValue && !open ? '--:--' : undefined}
           value={props.inputValue ?? '00:00'}
           size={props.size}
           onInputChange={(value) => setTime(value, props.inputValue)}
-          onFocus={() => setOpen(true)}
           rightContent={props.rightContent}
+          openImmediately
         />
         <DropdownMenu>{options()}</DropdownMenu>
       </Dropdown>

--- a/src/molecules/Dropdown/Dropdown.tsx
+++ b/src/molecules/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { DropdownContext, useDropdownContext, DropdownContextValues } from './context';
 import { useAccessibleDropdown } from './useAccessibleDropdown';
 import { getIndexedDropdownItems, getMaxHighlightIndex } from './utils';
@@ -6,6 +6,11 @@ import cn from 'classnames';
 
 type Props = {
   open?: boolean;
+  setOpen?: (open: boolean) => void;
+
+  /**
+   * @deprecated use setOpen instead
+   */
   toggle?: () => void;
   itemToggle?: boolean;
   fullWidth?: boolean;
@@ -23,6 +28,9 @@ export const Dropdown: React.FC<Props> = (props) => {
   const maxHighlightIndex = getMaxHighlightIndex(props.children);
 
   const toggle = () => setOpen(!open);
+  useEffect(() => {
+    props.setOpen?.(open);
+  }, [open]);
 
   const contextValue: DropdownContextValues = {
     open: props.open ? props.open : open,

--- a/src/molecules/Dropdown/DropdownMenu.tsx
+++ b/src/molecules/Dropdown/DropdownMenu.tsx
@@ -66,6 +66,7 @@ export const DropdownMenu: React.FC<DropdownMenuProps> = (props) => {
           : { visibility }
       }
       ref={menuRef}
+      tabIndex={-1}
     >
       {allItems}
     </div>


### PR DESCRIPTION
Har test den tab-index tingen i Dropdown-storyene også, og det funker fint. Den gjorde at man måtte tabbe to ganger for å komme ut av inputfeltet (fordi dropdown-menyen fikk fokus). Litt usikker på hvorfor det ikke har slått ut før 🤔 