### PR TITLE
Change onChange type in TextBoxWithLabel to play nice with event.target.value

### DIFF
--- a/src/molecules/TextBoxWithLabel/TextBoxWithLabel.d.ts
+++ b/src/molecules/TextBoxWithLabel/TextBoxWithLabel.d.ts
@@ -14,7 +14,7 @@ declare interface TextBoxWithLabelProps {
   iconLabel?: string;
   value?: string;
   ref?: any;
-  onChange?: (e: React.SyntheticEvent) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 declare const TextBoxWithLabel: React.FC<TextBoxWithLabelProps>;


### PR DESCRIPTION
React.SyntheticEvent does not expose the necessary types for the input change event.