### PR TITLE
Make possible additional paddding for the DropDownItem icon, if used

### DIFF
--- a/src/molecules/Dropdown/Dropdown.pcss
+++ b/src/molecules/Dropdown/Dropdown.pcss
@@ -111,7 +111,7 @@
   display: flex;
   align-items: center;
   color: var(--medium-dark-grey);
-  padding: 0.75rem 0.5rem;
+  padding: 1rem 0.95rem;
   margin: 0;
   font-size: 14px;
   background-color: white;
@@ -170,9 +170,12 @@
       font: inherit;
     }
   }
-  &__additional-icon-padding {
-    padding-left: 0.375rem;
+  &__icon-container {
     padding-right: 0.375rem;
+  }
+
+  &__sub-label {
+    padding-top:0.3rem;
   }
 }
 

--- a/src/molecules/Dropdown/Dropdown.pcss
+++ b/src/molecules/Dropdown/Dropdown.pcss
@@ -170,6 +170,10 @@
       font: inherit;
     }
   }
+  &__additional-icon-padding {
+    padding-left: 0.375rem;
+    padding-right: 0.375rem;
+  }
 }
 
 .telia-dropdown-item__clickable {

--- a/src/molecules/Dropdown/Dropdown.pcss
+++ b/src/molecules/Dropdown/Dropdown.pcss
@@ -173,10 +173,6 @@
   &__icon-container {
     padding-right: 0.375rem;
   }
-
-  &__sub-label {
-    padding-top:0.3rem;
-  }
 }
 
 .telia-dropdown-item__clickable {

--- a/src/molecules/Dropdown/Dropdown.stories.tsx
+++ b/src/molecules/Dropdown/Dropdown.stories.tsx
@@ -109,6 +109,14 @@ export const Default = () => {
                 <DropdownItem icon="user" label="Longer option with child" onClick={action('DropdownItem clicked')}>
                   Child
                 </DropdownItem>
+                <DropdownItem
+                  icon="user"
+                  extraIconPadding={true}
+                  label="Extra icon padding"
+                  onClick={action('DropdownItem clicked')}
+                >
+                  <span style={{ fontSize: '12px' }}>Some attenuated text</span>
+                </DropdownItem>
                 <DropdownItem label="Even longer than the long option" onClick={action('DropdownItem clicked')} />
               </DropdownMenu>
             </Dropdown>

--- a/src/molecules/Dropdown/Dropdown.stories.tsx
+++ b/src/molecules/Dropdown/Dropdown.stories.tsx
@@ -107,14 +107,6 @@ export const Default = () => {
                 <DropdownItem divider={true} />
                 <DropdownItem label="Centered" centered={true} onClick={action('DropdownItem clicked')} />
                 <DropdownItem icon="user" label="Longer option with child" onClick={action('DropdownItem clicked')}>
-                  Child
-                </DropdownItem>
-                <DropdownItem
-                  icon="user"
-                  extraIconPadding={true}
-                  label="Extra icon padding"
-                  onClick={action('DropdownItem clicked')}
-                >
                   <span style={{ fontSize: '12px' }}>Some attenuated text</span>
                 </DropdownItem>
                 <DropdownItem label="Even longer than the long option" onClick={action('DropdownItem clicked')} />

--- a/src/molecules/Dropdown/DropdownItem.tsx
+++ b/src/molecules/Dropdown/DropdownItem.tsx
@@ -106,13 +106,13 @@ export const DropdownItem: React.FC<DropdownItemProps> = (props) => {
   const content = (
     <>
       {props.icon ? (
-        <div className={cs({ 'telia-dropdown-item__additional-icon-padding': props.extraIconPadding })}>
+        <div className="telia-dropdown-item__icon-container">
           <Icon icon={props.icon} />
         </div>
       ) : null}
       <div>
         {props.label ? <div>{props.label}</div> : null}
-        <div>{props.children}</div>
+        {props.children ? <div className="telia-dropdown-item__sub-label">{props.children}</div> : null}
       </div>
     </>
   );

--- a/src/molecules/Dropdown/DropdownItem.tsx
+++ b/src/molecules/Dropdown/DropdownItem.tsx
@@ -27,11 +27,6 @@ export type DropdownItemProps = {
   icon?: IconDefinition;
 
   /**
-   * Give some additional horizontal padding around the icon if it is used
-   */
-  extraIconPadding?: boolean;
-
-  /**
    * Wheter the content of the item should be centered
    */
   centered?: boolean;
@@ -112,7 +107,7 @@ export const DropdownItem: React.FC<DropdownItemProps> = (props) => {
       ) : null}
       <div>
         {props.label ? <div>{props.label}</div> : null}
-        {props.children ? <div className="telia-dropdown-item__sub-label">{props.children}</div> : null}
+        <div>{props.children}</div>
       </div>
     </>
   );

--- a/src/molecules/Dropdown/DropdownItem.tsx
+++ b/src/molecules/Dropdown/DropdownItem.tsx
@@ -27,6 +27,11 @@ export type DropdownItemProps = {
   icon?: IconDefinition;
 
   /**
+   * Give some additional horizontal padding around the icon if it is used
+   */
+  extraIconPadding?: boolean;
+
+  /**
    * Wheter the content of the item should be centered
    */
   centered?: boolean;
@@ -101,7 +106,7 @@ export const DropdownItem: React.FC<DropdownItemProps> = (props) => {
   const content = (
     <>
       {props.icon ? (
-        <div>
+        <div className={cs({ 'telia-dropdown-item__additional-icon-padding': props.extraIconPadding })}>
           <Icon icon={props.icon} />
         </div>
       ) : null}


### PR DESCRIPTION
This one will allow for a more spacious layout when using icons in a dropdown. Will use it as this graphics shows
![image](https://user-images.githubusercontent.com/464085/108973205-60febd00-7684-11eb-9b62-85923f03aaef.png)
