### PR TITLE
Use dedicated css classname instead of mixing with Icon component styling. Reduce cascading

### DIFF
--- a/src/molecules/Dropdown/Dropdown.pcss
+++ b/src/molecules/Dropdown/Dropdown.pcss
@@ -130,7 +130,7 @@
   white-space: pre-wrap;
   text-align: left;
   width: 100%;
-  .Icon {
+  &__icon {
     width: 1rem;
     height: 1rem;
     margin-right: 0.5rem;

--- a/src/molecules/Dropdown/DropdownItem.tsx
+++ b/src/molecules/Dropdown/DropdownItem.tsx
@@ -110,7 +110,7 @@ export const DropdownItem: React.FC<DropdownItemProps> = (props) => {
       {props.leading ? props.leading : null}
       {props.icon && !props.leading && (
         <div className="telia-dropdown-item__icon-container">
-          <Icon icon={props.icon} />
+          <Icon className="telia-dropdown-item__icon" icon={props.icon} />
         </div>
       )}
       <div>


### PR DESCRIPTION
This change makes it possible and/or cleaner to use the dropdown item with e.g. a leading icon without its styling to collide with what the styleguide dictates.