### PR TITLE
Feature/design tweaks business

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -15,20 +15,28 @@ For Major and Minor changes in version you must notify everyone in the #stylegui
 
 Only noteworthy changes.
 
+## 1.41.0
+
+- Updated Chip component
+  - New size (32px for all), size prop is removed
+  - Square chip is added
+  - Kind prop is renamed to color
+  - Change classnames to fit BEM pattern
+- Updated TextField
+  - Help text is left by default
+- Updated PhoneNumberField
+  - Change classnames to fit BEM battern
+  - Added size prop
+
 ## 1.40.0
-- Refactored StepByStep component
-    - Written in typescript
-    - `Step`, `Content` and `Descriptions` were perviously properties of the `StepByStep` class. These are now exported as components from
-index.ts and accessed from @telia/styleguide as `Step`, `StepContent` and `StepDescription`.
-    - Enable customizing of icon, header and content in StepDescription
-    - Add different sizes for a StepByStep component
-    - Support dashed borders
-    - Disable animations for non-interactive StepByStep components
-    
+
+- Refactored StepByStep component - Written in typescript - `Step`, `Content` and `Descriptions` were perviously properties of the `StepByStep` class. These are now exported as components from
+  index.ts and accessed from @telia/styleguide as `Step`, `StepContent` and `StepDescription`. - Enable customizing of icon, header and content in StepDescription - Add different sizes for a StepByStep component - Support dashed borders - Disable animations for non-interactive StepByStep components
 
 ## 1.39.7
+
 - Added more colors to the [Color Palette](https://styleguide.channelapi.telia.no/?path=/docs/introduction-styleguide--color-palette)
-    - [Commit 385fc2c](https://github.com/TeliaSoneraNorge/styleguide/pull/931/commits/385fc2c34d4660a96d1b9c83318283847a2cfb2e)
+  - [Commit 385fc2c](https://github.com/TeliaSoneraNorge/styleguide/pull/931/commits/385fc2c34d4660a96d1b9c83318283847a2cfb2e)
 
 ## 1.39.0
 

--- a/src/atoms/Checkbox/Checkbox.pcss
+++ b/src/atoms/Checkbox/Checkbox.pcss
@@ -7,11 +7,11 @@
     padding: 0;
   }
 
-  &__checkbox:focus + &__icon-container {
+  &__checkbox:focus + &__checkbox-container {
     outline: 0;
   }
 
-  &__checkbox:focus + &__icon-container:before {
+  &__checkbox:focus + &__checkbox-container:before {
     content: ' ';
     display: inline-block;
     width: 1px;
@@ -24,10 +24,38 @@
     z-index: -100;
   }
 
+  &__container {
+    display: flex;
+  }
+
+  &__checkbox-container  {
+    display: inline-flex;
+    padding: 12px;
+    border-radius: 100px;
+    cursor: pointer;
+
+    &:hover {
+      background-color: var(--grey-200);
+    }
+
+    &:active {
+      background-color: var(--grey-300);
+    }
+
+    &--checked {
+      &:hover {
+        background-color: var(--core-purple-100);
+      }
+
+      &:active {
+        background-color: var(--core-purple-200);
+      }
+    }
+  }
+
   &__icon-container {
     width: 1.25rem;
     height: 1.25rem;
-    margin: 0.25rem;
     border: solid 2px var(--medium-dark-grey);
     border-radius: 2px;
     display: inline-block;
@@ -35,9 +63,13 @@
     cursor: pointer;
     color: var(--white);
     transition: 0.2s;
-    background-color: var(--white);
     vertical-align: middle;
     bottom: 0.05rem;
+
+    &:active {
+      background-color: var(--core-purple-700);
+      border-color: var(--core-purple-700);
+    }
 
     &--checked {
       border-color: var(--core-purple);
@@ -89,6 +121,12 @@
   }
 
   &__label {
+    align-self: center;
+
+    &:hover {
+      cursor: pointer;
+    }
+
     &--hidden {
       display: none;
     }

--- a/src/atoms/Checkbox/Checkbox.tsx
+++ b/src/atoms/Checkbox/Checkbox.tsx
@@ -52,41 +52,48 @@ export const Checkbox: React.FC<CheckboxProps> = (props) => {
         }}
         tabIndex={props.tabIndex ?? 0}
       />
-      <div
-        className={cs({
-          'telia-checkbox__icon-container': true,
-          'telia-checkbox__icon-container--checked':
-            ('partial' in props && props.partial) || ('checked' in props && props.checked),
-          'telia-checkbox__icon-container--disabled': props.disabled,
-          'telia-checkbox__icon-container--disabled-and-checked':
-            props.disabled && (('checked' in props && props.checked) || ('partial' in props && props.partial)),
-          [props.className]: props.className,
-        })}
-      >
-        <Icon
-          icon="check-mark"
-          className={cs('telia-checkbox__icon', {
-            'telia-checkbox__icon--visible': 'checked' in props && props.checked,
+      <div className="telia-checkbox__container">
+        <div
+          className={cs('telia-checkbox__checkbox-container', {
+            'telia-checkbox__checkbox-container--checked': 'checked' in props && props.checked,
           })}
-          style={{ width: '1rem', height: '1rem' }}
-        />
-        <Icon
-          icon="minus"
-          className={cs('telia-checkbox__icon', {
-            'telia-checkbox__icon--visible':
-              'checked' in props && !props.checked && 'partial' in props && props.partial,
+        >
+          <div
+            className={cs({
+              'telia-checkbox__icon-container': true,
+              'telia-checkbox__icon-container--checked':
+                ('partial' in props && props.partial) || ('checked' in props && props.checked),
+              'telia-checkbox__icon-container--disabled': props.disabled,
+              'telia-checkbox__icon-container--disabled-and-checked':
+                props.disabled && (('checked' in props && props.checked) || ('partial' in props && props.partial)),
+              [props.className]: props.className,
+            })}
+          >
+            <Icon
+              icon="check-mark"
+              className={cs('telia-checkbox__icon', {
+                'telia-checkbox__icon--visible': 'checked' in props && props.checked,
+              })}
+              style={{ width: '1rem', height: '1rem' }}
+            />
+            <Icon
+              icon="minus"
+              className={cs('telia-checkbox__icon', {
+                'telia-checkbox__icon--visible':
+                  'checked' in props && !props.checked && 'partial' in props && props.partial,
+              })}
+              style={{ width: '1rem', height: '1rem' }}
+            />
+          </div>{' '}
+        </div>
+        <span
+          className={cs('telia-checkbox__label', {
+            'telia-checkbox__label--hidden': props.hiddenLabel,
           })}
-          style={{ width: '1rem', height: '1rem' }}
-        />
+        >
+          {props.label}
+        </span>
       </div>
-      <span
-        className={cs({
-          checkbox__label: true,
-          'telia-checkbox__label--hidden': props.hiddenLabel,
-        })}
-      >
-        {props.label}
-      </span>
     </label>
   );
 };

--- a/src/atoms/RadioButton/RadioButton.pcss
+++ b/src/atoms/RadioButton/RadioButton.pcss
@@ -80,6 +80,25 @@
     background-color: var(--core-purple-100);
   }
 
+  /* On active effect, adding a gray shadow */
+  &:active > input ~ .radiobutton__svg-container {
+    background-color: var(--grey-300);
+  }
+
+  /* On active effect, adding a purple shadow when checked */
+  &:active > input:checked ~ .radiobutton__svg-container {
+    background-color: var(--core-purple-200);
+  }
+
+  /* On active effect, if the input is checked, make color of radio button darker purple */
+  &:active > input:checked ~ .radiobutton__svg-container .radiobutton__circle {
+    fill: var(--core-purple-700);
+  }
+
+  &:active > input:checked ~ .radiobutton__svg-container .radiobutton__border {
+    stroke: var(--core-purple-700);
+  }
+
   /* On focus effect, adding a blue border */
   & > input:focus + .radiobutton__svg-container {
     box-shadow: 0 0 0 2px transparent, 0 0 0 2px var(--blue-300);

--- a/src/molecules/Chip/Chip.pcss
+++ b/src/molecules/Chip/Chip.pcss
@@ -7,7 +7,7 @@
   display: flex;
   letter-spacing: 0.05rem;
   line-height: 1.25;
-  width: fit-content;
+  width: min-content;
   position: relative;
   text-decoration: none;
   align-items: center;

--- a/src/molecules/Chip/Chip.pcss
+++ b/src/molecules/Chip/Chip.pcss
@@ -33,25 +33,25 @@
     border-color: var(--grey-300);
   }
 
-  &--label {
+  &__label {
     display: inline-flex;
     overflow: hidden;
     text-align: start;
     line-height: 18px;
   }
 
-  &--icon {
+  &__icon {
     height: 1rem;
     width: 1rem;
     margin-right: 0.5rem;
     align-self: flex-start;
   }
 
-  &__input {
+  &--input {
     padding: 0.375rem 0.375rem 0.375rem 1rem;
   }
 
-  &__grey {
+  &--grey {
     background-color: var(--grey-200);
     color: var(--grey-700);
     border-color: var(--grey-200);
@@ -68,7 +68,7 @@
     }
   }
 
-  &__disabled {
+  &--disabled {
     pointer-events: none;
     background-color: var(--grey-200);
     color: var(--grey-300);
@@ -76,8 +76,8 @@
   }
 }
 
-.telia-chip__choice.telia-chip--hasIcon,
-.telia-chip__input.telia-chip--hasIcon {
+.telia-chip--choice.telia-chip--hasIcon,
+.telia-chip--input.telia-chip--hasIcon {
   padding-left: 0.5rem;
 }
 
@@ -85,22 +85,22 @@
   border-radius: 4px;
 }
 
-.telia-chip__choice.telia-chip--square {
+.telia-chip--choice.telia-chip--square {
   padding: 0.375rem 0.5rem;
 }
 
-.telia-chip__input.telia-chip--square {
+.telia-chip--input.telia-chip--square {
   padding: 0.375rem 0.5rem;
 }
 
-.telia-chip__input.telia-chip__active {
+.telia-chip--input.telia-chip--active {
   cursor: default;
   &:focus {
     box-shadow: none;
   }
 }
 
-.telia-chip__choice.telia-chip__active {
+.telia-chip--choice.telia-chip--active {
   background-color: var(--core-purple-100);
   border-color: var(--core-purple-100);
   color: var(--core-purple-500);
@@ -112,7 +112,7 @@
   }
 }
 
-.telia-chip .telia-chip--close {
+.telia-chip .telia-chip__closeBtn {
   background-color: var(--grey-400);
   color: var(--white);
   padding: 0.2rem;
@@ -130,21 +130,21 @@
 }
 
 .telia-chip:hover {
-  .telia-chip--close {
+  .telia-chip__closeBtn {
     background-color: var(--grey-500);
   }
 }
-.telia-chip__grey:hover {
-  .telia-chip--close {
+.telia-chip--grey:hover {
+  .telia-chip__closeBtn {
     background-color: var(--grey-700);
   }
 }
 
-.telia-chip.telia-chip__disabled .telia-chip--close {
+.telia-chip--disabled .telia-chip__closeBtn {
   background-color: var(--grey-200);
   color: var(--grey-400);
 }
 
-.telia-chip__input .telia-chip-icon {
+.telia-chip--input .telia-chip__icon {
   align-self: center;
 }

--- a/src/molecules/Chip/Chip.pcss
+++ b/src/molecules/Chip/Chip.pcss
@@ -1,6 +1,6 @@
 .telia-chip {
   background-color: var(--white);
-  border: 1px solid var(--grey-200);
+  border: 1px solid var(--grey-300);
   border-radius: 2rem;
   color: var(--grey-700);
   cursor: pointer;
@@ -12,6 +12,8 @@
   text-decoration: none;
   align-items: center;
   transition: all 200ms ease-in-out;
+  padding: 0.375rem 1rem;
+  font-size: 14px;
 
   &:hover {
     background-color: var(--grey-200);
@@ -27,6 +29,8 @@
   &:active {
     outline: none;
     box-shadow: none;
+    background-color: var(--grey-300);
+    border-color: var(--grey-300);
   }
 
   &--label {
@@ -39,18 +43,28 @@
   &--icon {
     height: 1rem;
     width: 1rem;
-    margin-right: 0.2rem;
+    margin-right: 0.5rem;
     align-self: flex-start;
+  }
+
+  &__input {
+    padding: 0.375rem 0.375rem 0.375rem 1rem;
   }
 
   &__grey {
     background-color: var(--grey-200);
     color: var(--grey-700);
+    border-color: var(--grey-200);
 
     &:hover {
       background-color: var(--grey-300);
       color: var(--grey-900);
       border-color: var(--grey-300);
+    }
+
+    &:active {
+      background-color: var(--grey-400);
+      border-color: var(--grey-400);
     }
   }
 
@@ -58,29 +72,25 @@
     pointer-events: none;
     background-color: var(--grey-200);
     color: var(--grey-300);
+    border-color: var(--grey-200);
   }
 }
-.telia-chip__choice {
-  padding: 0.75rem 1.5rem;
+
+.telia-chip__choice.telia-chip--hasIcon,
+.telia-chip__input.telia-chip--hasIcon {
+  padding-left: 0.5rem;
 }
 
-.telia-chip__input {
-  padding: 0.75rem;
-  padding-right: 10px;
-  padding-left: 1.25rem;
+.telia-chip--square {
+  border-radius: 4px;
 }
 
-.telia-chip__compact {
-  font-size: 14px;
+.telia-chip__choice.telia-chip--square {
+  padding: 0.375rem 0.5rem;
 }
 
-.telia-chip__compact.telia-chip__choice {
-  padding: 0.5rem 1.25rem;
-}
-
-.telia-chip__compact.telia-chip__input {
-  padding: 0.5rem;
-  padding-left: 1rem;
+.telia-chip__input.telia-chip--square {
+  padding: 0.375rem 0.5rem;
 }
 
 .telia-chip__input.telia-chip__active {

--- a/src/molecules/Chip/Chip.stories.tsx
+++ b/src/molecules/Chip/Chip.stories.tsx
@@ -20,37 +20,35 @@ export const ChoiceChips = () => (
       <div>Chip with icon:</div>
     </div>
     <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '25% 25% 25% 25%' }}>
-      <Chip label="Chippy" size="compact" />
-      <Chip label="Chippy" size="compact" active />
-      <Chip label="Chippy" size="compact" disabled />
-      <Chip label="Chippy" size="compact" icon="check-mark" />
-    </div>
-    <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '25% 25% 25% 25%' }}>
       <Chip label="Chippy" />
       <Chip label="Chippy" active />
       <Chip label="Chippy" disabled />
       <Chip label="Chippy" icon="check-mark" />
     </div>
     <br />
-    <br />
     <h3>Choice Chip - Grey</h3>
     <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '25% 25% 25% 25%' }}>
-      <Chip label="Chippy" size="compact" kind="grey" />
+      <Chip label="Chippy" color="grey" />
 
-      <Chip label="Chippy" size="compact" active kind="grey" />
+      <Chip label="Chippy" active color="grey" />
 
-      <Chip label="Chippy" size="compact" disabled kind="grey" />
+      <Chip label="Chippy" disabled color="grey" />
 
-      <Chip label="Chippy" size="compact" icon="check-mark" kind="grey" />
+      <Chip label="Chippy" icon="check-mark" color="grey" />
     </div>
-    <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '25% 25% 25% 25%' }}>
-      <Chip label="Chippy" size="compact" kind="grey" />
 
-      <Chip label="Chippy" active kind="grey" />
-
-      <Chip label="Chippy" disabled kind="grey" />
-
-      <Chip label="Chippy" icon="check-mark" kind="grey" />
+    <h3>Square Chip</h3>
+    <div>White</div>
+    <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '33% 33% 33%' }}>
+      <Chip label="Chippy" mode="choice" kind="square" />
+      <Chip label="Chippy" mode="choice" disabled kind="square" />
+      <Chip label="Chippy" mode="choice" icon="check-mark" kind="square" />
+    </div>
+    <div>Grey</div>
+    <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '33% 33% 33%' }}>
+      <Chip label="Chippy" mode="choice" color="grey" kind="square" />
+      <Chip label="Chippy" mode="choice" color="grey" disabled kind="square" />
+      <Chip label="Chippy" mode="choice" color="grey" icon="check-mark" kind="square" />
     </div>
   </div>
 );
@@ -66,31 +64,31 @@ export const InputChips = () => (
       <div>Disabled state:</div>
       <div>Chip with icon:</div>
     </div>
-
-    <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '33% 33% 33%' }}>
-      <Chip label="Chippy" mode="input" size="compact" />
-      <Chip label="Chippy" mode="input" size="compact" disabled />
-      <Chip label="Chippy" mode="input" size="compact" icon="check-mark" />
-    </div>
-
     <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '33% 33% 33%' }}>
       <Chip label="Chippy" mode="input" />
       <Chip label="Chippy" mode="input" disabled />
       <Chip label="Chippy" mode="input" icon="check-mark" />
     </div>
     <br />
-    <br />
     <h3>Input Chip - Grey</h3>
     <br />
     <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '33% 33% 33%' }}>
-      <Chip label="Chippy" mode="input" kind="grey" size="compact" />
-      <Chip label="Chippy" mode="input" kind="grey" size="compact" disabled />
-      <Chip label="Chippy" mode="input" kind="grey" size="compact" icon="check-mark" />
+      <Chip label="Chippy" mode="input" color="grey" />
+      <Chip label="Chippy" mode="input" color="grey" disabled />
+      <Chip label="Chippy" mode="input" color="grey" icon="check-mark" />
     </div>
+    <h3>Square Chip</h3>
+    <div>White</div>
     <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '33% 33% 33%' }}>
-      <Chip label="Chippy" mode="input" kind="grey" />
-      <Chip label="Chippy" mode="input" kind="grey" disabled />
-      <Chip label="Chippy" mode="input" kind="grey" icon="check-mark" />
+      <Chip label="Chippy" mode="input" kind="square" />
+      <Chip label="Chippy" mode="input" disabled kind="square" />
+      <Chip label="Chippy" mode="input" icon="check-mark" kind="square" />
+    </div>
+    <div>Grey</div>
+    <div style={{ paddingBottom: '1rem', display: 'grid', gridTemplateColumns: '33% 33% 33%' }}>
+      <Chip label="Chippy" mode="input" color="grey" kind="square" />
+      <Chip label="Chippy" mode="input" color="grey" disabled kind="square" />
+      <Chip label="Chippy" mode="input" color="grey" icon="check-mark" kind="square" />
     </div>
   </div>
 );

--- a/src/molecules/Chip/Chip.tsx
+++ b/src/molecules/Chip/Chip.tsx
@@ -45,11 +45,11 @@ export const Chip = ({ label, icon, active, disabled, color, kind, mode = 'choic
       type={Tag === 'button' ? 'button' : undefined}
       className={cs(
         'telia-chip',
-        `telia-chip__${mode}`,
+        `telia-chip--${mode}`,
         {
-          'telia-chip__disabled': disabled,
-          'telia-chip__active': active || mode === 'input',
-          'telia-chip__grey': color === 'grey',
+          'telia-chip--disabled': disabled,
+          'telia-chip--active': active || mode === 'input',
+          'telia-chip--grey': color === 'grey',
           'telia-chip--square': kind === 'square',
           'telia-chip--hasIcon': icon,
         },
@@ -64,15 +64,15 @@ export const Chip = ({ label, icon, active, disabled, color, kind, mode = 'choic
       }}
       tabIndex={disabled || mode === 'input' ? -1 : 0}
     >
-      {icon && <Icon className="telia-chip--icon" icon={icon} />}
-      <div className="telia-chip--label">{label}</div>
+      {icon && <Icon className="telia-chip__icon" icon={icon} />}
+      <div className="telia-chip__label">{label}</div>
       {mode === 'input' && (
         <Button
           kind="secondary-text"
           icon="close"
           onClick={onClick}
           disabled={disabled}
-          className="telia-chip--close"
+          className="telia-chip__closeBtn"
         />
       )}
     </Tag>

--- a/src/molecules/Chip/Chip.tsx
+++ b/src/molecules/Chip/Chip.tsx
@@ -21,14 +21,13 @@ type Props = {
    */
   mode?: 'choice' | 'input';
   /**
-   * Styling of chip. Default is white.
+   * Color of chip. Default is white.
    */
-  kind?: 'white' | 'grey';
+  color?: 'white' | 'grey';
   /**
-   * Styling of chip. Default is white.
+   * Styling of chip. Default is rounded.
    */
-  size?: 'compact' | 'default';
-
+  kind?: 'rounded' | 'square';
   /**
    * The click event for the whole chip (in filter mode) or for the remove button (in select mode).
    */
@@ -37,17 +36,7 @@ type Props = {
   className?: string;
 };
 
-export const Chip = ({
-  label,
-  icon,
-  active,
-  disabled,
-  kind,
-  mode = 'choice',
-  size = 'default',
-  onClick,
-  className,
-}: Props) => {
+export const Chip = ({ label, icon, active, disabled, color, kind, mode = 'choice', onClick, className }: Props) => {
   const Tag = mode === 'input' ? 'div' : 'button';
   const role = Tag === 'div' && !(mode === 'input') ? 'button' : undefined;
   return (
@@ -58,10 +47,11 @@ export const Chip = ({
         'telia-chip',
         `telia-chip__${mode}`,
         {
-          'telia-chip__compact': size === 'compact',
           'telia-chip__disabled': disabled,
           'telia-chip__active': active || mode === 'input',
-          'telia-chip__grey': kind === 'grey',
+          'telia-chip__grey': color === 'grey',
+          'telia-chip--square': kind === 'square',
+          'telia-chip--hasIcon': icon,
         },
         className
       )}

--- a/src/molecules/PhoneNumberField/PhoneNumberField.pcss
+++ b/src/molecules/PhoneNumberField/PhoneNumberField.pcss
@@ -4,9 +4,21 @@
   position: relative;
 
   .telia-dropdown {
-    button {
-      height: 100%;
+    button.telia-dropdown-toggle {
+      height: 44px;
+      width: 84px;
+      padding: 12px;
+      justify-content: flex-end;
+
+      .Icon {
+        height: 15px;
+        width: 15px;
+      }
     }
+  }
+
+  .telia-dropdown-content {
+    width: fit-content;
   }
 
   .telia-dropdown-toggle__outline {
@@ -21,41 +33,79 @@
     width: 100%;
   }
 
+  .telia-textfield__input {
+    color: var(--grey-900);
+  }
+
   .telia-textfield__content {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+    height: 44px;
   }
 
-  &__error {
+  .telia-textfield--withValue .telia-textfield__content {
+    border-color: var(--accent-250);
+  }
+
+  &--compact {
+    .telia-dropdown {
+      button.telia-dropdown-toggle {
+        padding: 8px;
+        height: 36px;
+        width: 68px;
+        font-size: 14px;
+
+        .Icon {
+          height: 12px;
+          width: 12px;
+        }
+      }
+    }
+
+    .telia-textfield__content {
+      height: 36px;
+      font-size: 14px;
+    }
+
+    .telia-textfield--compact {
+      margin-top: 0;
+    }
+  }
+
+  &--error {
     .telia-dropdown-toggle__outline {
+      border-color: var(--red-600);
+    }
+
+    .telia-textfield--withValue .telia-textfield__content {
       border-color: var(--red-600);
     }
   }
 }
 
-.telia-phonenumber-countryCode__active {
+.telia-phonenumber__countryCode--active {
   .telia-dropdown-toggle__outline {
     border-color: var(--core-purple-500);
   }
 
   .telia-textfield__content {
-    border-left-color: var(--core-purple-500);
+    border-left-color: var(--core-purple-500) !important;
   }
 }
 
-.telia-phonenumber-helptext {
+.telia-phonenumber__helptext {
   color: var(--grey-600);
   display: block;
   float: right;
 }
 
-.telia-phonenumber-helptext--error {
+.telia-phonenumber__helptext--error {
   color: var(--red-600);
   display: block;
   float: left;
 }
 
-.telia-phonenumber-label {
+.telia-phonenumber__label {
   position: absolute;
   top: -20px;
   font-size: 14px;

--- a/src/molecules/PhoneNumberField/PhoneNumberField.stories.tsx
+++ b/src/molecules/PhoneNumberField/PhoneNumberField.stories.tsx
@@ -108,6 +108,19 @@ export const Default = () => {
             onChangeCountryCode={setCountryCode}
             disabled
           />
+          <br />
+          <br />
+          With <code>{'size="compact"'}</code>
+          <PhoneNumberField
+            countryCodes={countryCodes}
+            number={number}
+            countryCode={countryCode}
+            onChangeNumber={setNumber}
+            onChangeCountryCode={setCountryCode}
+            size="compact"
+          />
+          <br />
+          <br />
         </div>
       </div>
     </>

--- a/src/molecules/PhoneNumberField/PhoneNumberField.tsx
+++ b/src/molecules/PhoneNumberField/PhoneNumberField.tsx
@@ -21,6 +21,7 @@ export type PhoneNumberFieldProps = {
   placeholder?: string;
   label?: string;
   disabled?: boolean;
+  size?: 'default' | 'compact';
   /**
    * Event handler to allow handling validations after on blur
    */
@@ -35,11 +36,12 @@ export const PhoneNumberField = (props: PhoneNumberFieldProps) => {
     <div>
       <div
         className={cn('telia-phonenumber', {
-          'telia-phonenumber__error': props.error,
-          'telia-phonenumber-countryCode__active': open,
+          'telia-phonenumber--compact': props.size === 'compact',
+          'telia-phonenumber--error': props.error,
+          'telia-phonenumber__countryCode--active': open,
         })}
       >
-        {props.label && <label className={cn('telia-phonenumber-label')}>{props.label}</label>}
+        {props.label && <label className={cn('telia-phonenumber__label')}>{props.label}</label>}
         <Dropdown open={open} setOpen={setOpen}>
           <DropdownToggle label={countryCode} color="white" disabled={props.disabled} />
           <DropdownMenu>
@@ -56,9 +58,10 @@ export const PhoneNumberField = (props: PhoneNumberFieldProps) => {
           disabled={props.disabled}
           maxlength={props.maxlength}
           onBlur={props.onBlur}
+          size={props.size === 'compact' ? 'compact' : 'default'}
         />
       </div>
-      <small className={cn('telia-phonenumber-helptext', { 'telia-phonenumber-helptext--error': props.error })}>
+      <small className={cn('telia-phonenumber__helptext', { 'telia-phonenumber__helptext--error': props.error })}>
         {props.helpText}
       </small>
     </div>

--- a/src/molecules/TextField/TextField.pcss
+++ b/src/molecules/TextField/TextField.pcss
@@ -98,7 +98,6 @@
 .telia-textfield__helptext {
   color: var(--grey-700);
   display: block;
-  text-align: end;
 }
 
 .telia-textfield--focus {

--- a/src/molecules/TextField/TextField.pcss
+++ b/src/molecules/TextField/TextField.pcss
@@ -2,7 +2,7 @@
   position: relative;
   input {
     flex-grow: 1;
-    padding: 0.625rem 0.625rem 0.625rem 0.75rem;
+    padding: 0.75rem;
     font-size: 16px;
     line-height: 20px;
     border: none;
@@ -30,8 +30,8 @@
 }
 
 .telia-textfield__leftContent .telia-button--compact .telia-button--icon {
-  width: 1.125rem;
-  height: 1.125rem;
+  width: 16px;
+  height: 16px;
 }
 
 .telia-textfield__label {
@@ -60,6 +60,7 @@
 .telia-textfield__status {
   display: flex;
   align-items: center;
+  align-self: center;
   justify-content: center;
   width: 40px;
   height: 40px;
@@ -91,8 +92,8 @@
 
 .telia-textfield__leftContent > .Icon,
 .telia-textfield__rightContent > .Icon {
-  width: 27px;
-  height: 27px;
+  width: 20px;
+  height: 20px;
 }
 
 .telia-textfield__helptext {
@@ -175,7 +176,7 @@
 
   input {
     font-size: 14px;
-    padding: 0.5rem;
+    padding: 0.5rem 0.625rem;
   }
 }
 

--- a/src/molecules/TextField/TextField.stories.tsx
+++ b/src/molecules/TextField/TextField.stories.tsx
@@ -30,7 +30,7 @@ export const Default = () => {
             helpText={state === 'error' ? state : ''}
           />
           <TextField label="Field label" helpText="Help or instrictions" />
-          <TextField label="Field label" helpText={<div style={{ textAlign: 'start' }}>Help on left side</div>} />
+          <TextField label="Field label" helpText={<div style={{ textAlign: 'end' }}>Help on right side</div>} />
           <TextField label="Field label" error={true} helpText="Error message" />
           <TextField label="Field label" success={true} helpText="Success message" />
         </div>
@@ -41,7 +41,7 @@ export const Default = () => {
             helpText="Help or instrictions"
             rightContent={<Button size="compact" kind="secondary-text" icon="close" onClick={action('button')} />}
           />
-          <TextField label="Field label" helpText={<div style={{ textAlign: 'start' }}>Help on left side</div>} />
+          <TextField label="Field label" helpText={<div style={{ textAlign: 'end' }}>Help on right side</div>} />
           <TextField label="Field label" error={true} helpText="Error message" />
           <TextField label="Field label" success={true} helpText="Success message" />
         </div>


### PR DESCRIPTION
TextField:
- Update paddings
- Help text is left by default
- Height for default is 44px, height for compact is 36 px


Chip:
- Update paddings
- Size is set to 32px for all
- Square kind added
- previous kind (white/grey) is now called color. and kind is used to set rounded or square (BREAKING CHANGE!!)
- Added active colors

Checkbox:
- Add larger hovering and clickable area for checkbox - similar to radio btns
- Add active colors

PhoneNumberField:
- Height to 44px
- Added compact size
- fixed some border colors (due to updates in Textfield)
- set fixed width to fit 3 digits in country code 

RadioButton:
- Add active style 