### PR TITLE
Fix color for disabled label due to contrast

### DIFF
--- a/src/molecules/TextField/TextField.pcss
+++ b/src/molecules/TextField/TextField.pcss
@@ -134,7 +134,7 @@
 .telia-textfield--disabled {
   .telia-textfield__label,
   .telia-textfield__helptext {
-    color: var(--grey-300);
+    color: var(--grey-400);
   }
   .telia-textfield__content {
     background-color: var(--grey-100);


### PR DESCRIPTION
It was decided at the ux meeting to use A0A0A0