### PR TITLE
Bugfix/add defaultprops breadcrumbs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@telia/styleguide",
-    "version": "1.41.12",
+    "version": "1.41.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@telia/styleguide",
-    "version": "1.41.12",
+    "version": "1.41.13",
     "private": true,
     "description": "",
     "main": "dist/index.js",

--- a/src/molecules/BreadCrumbs/BreadCrumbs.jsx
+++ b/src/molecules/BreadCrumbs/BreadCrumbs.jsx
@@ -148,4 +148,8 @@ const BreadCrumbs = (props) => {
   );
 };
 
+BreadCrumbs.defaultProps = {
+  crumbs: [],
+};
+
 export default BreadCrumbs;

--- a/src/molecules/BreadCrumbs/BreadCrumbs.stories.tsx
+++ b/src/molecules/BreadCrumbs/BreadCrumbs.stories.tsx
@@ -1,7 +1,6 @@
 import { boolean } from '@storybook/addon-knobs';
 import React from 'react';
 import { BreadCrumbs } from '../../index';
-import { BreadCrumbsProps } from './BreadCrumbs';
 
 export default {
   title: 'Component library/Molecules/BreadCrumbs',


### PR DESCRIPTION
Add deffault props to handle passing model from .net backend. If empty array is passed - default props should be used.