### PR TITLE
Avoid using relative and translate to support overlay

### DIFF
--- a/src/business/Button/Button.pcss
+++ b/src/business/Button/Button.pcss
@@ -14,7 +14,6 @@
   height: 44px;
   width: fit-content;
   padding: 0.75rem 1.5rem;
-  position: relative;
   text-decoration: none;
   transition: background-color 0.15s, color 0.15s;
 
@@ -37,19 +36,25 @@
   &__icon {
     height: 1.125rem;
     width: 1.125rem;
-    transform: translateX(-50%);
     align-self: center;
+    margin-right: 0.5rem;
   }
 
   &--ball {
     border-radius: 100%;
     justify-content: center;
-    padding: 0.5rem;
+    height: 44px;
     width: 44px;
+    padding: 1px;
+  }
+
+  &--iconLeft {
+    padding-left: 0.75rem;
   }
 
   &--iconRight {
     flex-direction: row-reverse;
+    padding-right: 0.75rem;
   }
 
   &--primary {
@@ -240,13 +245,15 @@
 }
 
 .telia-button--ball > .telia-button__icon {
-  transform: none;
   height: 1.5rem;
   width: 1.5rem;
+  margin: 0;
+  padding: 0;
 }
 
 .telia-button--ball.telia-button--compact {
   width: 36px;
+  height: 36px;
   .telia-button__icon {
     height: 1.25rem;
     width: 1.25rem;
@@ -256,8 +263,23 @@
 .telia-button--compact > .telia-button__icon {
   height: 0.875rem;
   width: 0.875rem;
+  margin-right: 6px;
 }
 
 .telia-button--iconRight > .telia-button__icon {
-  transform: translateX(50%);
+  margin-left: 8px;
+  margin-right: 0;
+}
+
+.telia-button--compact.telia-button--iconRight > .telia-button__icon {
+  margin-left: 6px;
+  margin-right: 0;
+}
+
+.telia-button--ball.telia-button--iconLeft {
+  padding: 0;
+}
+
+.telia-button--ball.telia-button--compact > .telia-button__icon {
+  margin: 0px;
 }

--- a/src/business/Button/Button.stories.tsx
+++ b/src/business/Button/Button.stories.tsx
@@ -20,9 +20,11 @@ export const ButtonPrimary = () => (
     <br />
     <h3>Button with icon</h3>
     <Button label="Button" icon={'add'} />
+    <Button label="Button" icon={'add'} size="compact" />
     <br />
     <h3>Button with icon right</h3>
     <Button label="Button" icon={'arrow-right'} iconRight={true} />
+    <Button label="Button" icon={'arrow-right'} iconRight={true} size="compact" />
     <br />
     <h3>Button ball (with icon and without label)</h3>
     <Button icon={'add'} ariaLabel="add" />

--- a/src/business/Button/Button.tsx
+++ b/src/business/Button/Button.tsx
@@ -85,6 +85,7 @@ export const Button = (props: ButtonProps) => {
         `telia-button--${size}`,
         {
           'telia-button--iconRight': iconRight,
+          'telia-button--iconLeft': icon && !iconRight,
           'telia-button--ball': icon && !label,
           'telia-button--disabled': disabled,
           'telia-button--active': active,


### PR DESCRIPTION
Jobber med å få menyen til å slide over portalen på små skjermer. Da fant jeg ut at når man setter på opacity på bakgrunnen fungerer ikke dette på knappene, fordi de hadde relative på seg 😅  Måtte derfor refaktorere litt