### PR TITLE
Allow child element to start focus on Modal open

### DIFF
--- a/src/molecules/ModalDialog/ModalDialog.d.ts
+++ b/src/molecules/ModalDialog/ModalDialog.d.ts
@@ -14,6 +14,7 @@ declare interface ModalDialogProps {
   closeText?: string;
   closeKind?: ButtonKind;
   standalone?: boolean;
+  focusChildElement?: boolean;
   renderTo?: any;
   headerElement?: React.ReactElement<any>;
   footerElement?: React.ReactElement<any>;

--- a/src/molecules/ModalDialog/ModalDialog.jsx
+++ b/src/molecules/ModalDialog/ModalDialog.jsx
@@ -30,6 +30,7 @@ function ModalDialog({
   closeText,
   closeKind,
   standalone,
+  focusChildElement,
   renderTo,
   headerElement,
   footerElement,
@@ -52,7 +53,7 @@ function ModalDialog({
   };
 
   const setFocusOnDialog = () => {
-    if (!dialogRef.current || standalone) return;
+    if (!dialogRef.current || standalone || focusChildElement) return;
 
     dialogRef.current.focus();
   };
@@ -72,12 +73,12 @@ function ModalDialog({
     };
   };
 
-  const onOverlayClick = event => {
+  const onOverlayClick = (event) => {
     if (event.target !== dialogOverlayRef.current) return;
     if (onClose) onClose();
   };
 
-  const handleKeyDown = event => {
+  const handleKeyDown = (event) => {
     if (event.keyCode === KEY_ESC && onClose) onClose();
   };
 


### PR DESCRIPTION
Need this to allow autofocus on input within Modal.
Before Modal would always steel focus after initial rendering of input.