### PR TITLE
Fix font-family to menu dropdown row

### DIFF
--- a/src/molecules/Menu/MobileMenu/MobileMenu.pcss
+++ b/src/molecules/Menu/MobileMenu/MobileMenu.pcss
@@ -201,7 +201,7 @@
       padding: 0 0.25rem;
       cursor: pointer;
       &__header {
-        font-weight: bold;
+        font-family: 'TeliaSans-Medium', Helvetica, Arial, sans-serif;
       }
       &__arrow-button {
         border: none;


### PR DESCRIPTION
Without this the dropdown row looks slightly "lighter" in boldness compared to the other menu elements as can be seen in the screensot below.