### PR TITLE
Override apple-system-blue for default html-tag value - set to black

### DIFF
--- a/src/atoms/Box/Box.pcss
+++ b/src/atoms/Box/Box.pcss
@@ -238,6 +238,7 @@
 
     /* Close button */
     &__close-expanded-info {
+        color: black;
         background-color: transparent;
         border: none;
         cursor: pointer;

--- a/src/atoms/Button/Button.pcss
+++ b/src/atoms/Button/Button.pcss
@@ -13,7 +13,6 @@
 }
 
 .button {
-  color: black;
   background-color: var(--white);
   border: 1px solid var(--core-purple);
   border-radius: 2rem;

--- a/src/atoms/Button/Button.pcss
+++ b/src/atoms/Button/Button.pcss
@@ -13,6 +13,7 @@
 }
 
 .button {
+  color: black;
   background-color: var(--white);
   border: 1px solid var(--core-purple);
   border-radius: 2rem;

--- a/src/molecules/Avatar/Avatar.pcss
+++ b/src/molecules/Avatar/Avatar.pcss
@@ -53,6 +53,7 @@
 }
 
 button.telia-avatar {
+  color: black;
   padding: 0;
   maringe: 0;
   border: 0;

--- a/src/molecules/BigImageDialog/BigImageDialog.pcss
+++ b/src/molecules/BigImageDialog/BigImageDialog.pcss
@@ -34,6 +34,7 @@
   }
 
   &__close-container {
+    color: black;
     background-color: transparent;
     border: none;
     cursor: pointer;

--- a/src/molecules/DropDownListWithLabel/DropDownListWithLabel.pcss
+++ b/src/molecules/DropDownListWithLabel/DropDownListWithLabel.pcss
@@ -4,6 +4,7 @@
     flex-direction: column;
 
     &__select {
+        color: black;
         border-radius: 0.25em;
         background: transparent url('{{assetPath}}/icons-legacy/ico_dropArrow.svg') no-repeat right 10px center;
         background-size: 15px 15px;

--- a/src/molecules/Dropdown/Dropdown.pcss
+++ b/src/molecules/Dropdown/Dropdown.pcss
@@ -33,6 +33,7 @@
   transition-property: background-color;
 
   &__default {
+    color: black;
     padding: 0 1rem;
     border-radius: 4px;
     border: none;

--- a/src/molecules/Menu/MenuCart.pcss
+++ b/src/molecules/Menu/MenuCart.pcss
@@ -66,6 +66,7 @@
   }
 
   &__icon-container {
+    color: black;
     position: relative;
   }
   &__icon {

--- a/src/molecules/Menu/MobileMenu/MobileMenu.pcss
+++ b/src/molecules/Menu/MobileMenu/MobileMenu.pcss
@@ -66,6 +66,7 @@
     }
 
     &-button {
+      color: black;
       box-shadow: none;
       background-color: transparent;
       border: none;


### PR DESCRIPTION
For iOS button has color -apple-system-blue. When running styleguide components on iOS default color is not black. Explicitly set color to black.