### PR TITLE
remove z- index on toggle thumb

### DIFF
--- a/src/atoms/Toggle/Toggle.pcss
+++ b/src/atoms/Toggle/Toggle.pcss
@@ -36,7 +36,6 @@
     border-radius: 50%;
     background-color: var(--white);
     transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
-    z-index: 2;
     position: absolute;
     top: 0.125rem;
     right: 1.25rem;


### PR DESCRIPTION
Removed the z-index because it shows up on top of fixed footer when scrolling. Doesn't seem to be necessary to function as it should, but want to check if it was added for a specific reason? 😅 