### PR TITLE
Fix image scaling for items

### DIFF
--- a/src/molecules/ShoppingCartV2/ShoppingCart.stories.tsx
+++ b/src/molecules/ShoppingCartV2/ShoppingCart.stories.tsx
@@ -440,6 +440,45 @@ export const subscriptionsOnly = () => {
       },
     },
     {
+      type: 'SPECIALPRODUCT',
+      id: '39961249',
+      bundleId: 'f108e0',
+      image: {
+        url: 'https://www.telia.no/shop/assets/img-static/other/missing_image.svg',
+      },
+      name: 'Kontant Startpakke',
+      quantity: {
+        modifiable: false,
+        removable: false,
+        value: 1,
+      },
+      price: {
+        upfront: 99,
+        originalSalesPrice: 99,
+        originalSalesPriceWithoutVAT: 79.2,
+      },
+      leaseMonths: null,
+      items: [
+        {
+          type: 'SUBSCRIPTION_DRAFT',
+          id: 'KONTANT_KOMPLETT.REGULAR',
+          bundleId: 'f108e0',
+          items: [],
+          name: 'Kontant Startpakke',
+          quantity: {
+            modifiable: false,
+            removable: false,
+            value: 1,
+          },
+          price: {},
+          image: {
+            icon: 'sim-card',
+          },
+          subtitle: 'Mobilabonnement',
+        },
+      ],
+    },
+    {
       type: 'SIM',
       id: '9054990',
       subtitle: 'Hovedsim',

--- a/src/molecules/ShoppingCartV2/ShoppingCartItem.pcss
+++ b/src/molecules/ShoppingCartV2/ShoppingCartItem.pcss
@@ -46,8 +46,9 @@
 
     &__quantity-picker-wrapper {
       display: flex;
-      justify-content: center;
+      justify-content: flex-start;
       align-items: center;
+      flex-wrap: wrap;
 
       .telia-shopping-cart__item__price-per {
         margin-left: 1rem;
@@ -120,10 +121,17 @@
     &__image,
     &__no-image {
       &__container {
-        max-width: 5rem;
-        width: 5rem;
-        padding: 1rem 1rem 0 1rem;
+        max-width: 2.5rem;
+        width: 2.5rem;
+        margin: 1rem 1rem 0 1rem;
       }
+    }
+
+    &__image {
+      display: block;
+      height: auto;
+      max-width: 2.5rem;
+      width: 2.5rem;
     }
 
     &__delete-button {


### PR DESCRIPTION
Also make price per unit wrap on small screens

Screens (image / icons)
![Screenshot 2022-03-18 at 15 50 10](https://user-images.githubusercontent.com/5881281/159026237-69147ae9-5224-47c5-9bf8-c919fc9b324b.png)
![Screenshot 2022-03-18 at 15 50 32](https://user-images.githubusercontent.com/5881281/159026234-09535055-26b1-4309-b451-3945c5f02928.png)

Screens (price per unit wraps):
![Screenshot 2022-03-18 at 15 49 15](https://user-images.githubusercontent.com/5881281/159026309-838e500f-6e23-4ef2-b3e5-deba085739ca.png)
![Screenshot 2022-03-18 at 15 49 10](https://user-images.githubusercontent.com/5881281/159026313-4622141e-5d9b-44b4-b57f-6ee82f60509e.png)

