### PR TITLE
BreadCrumb and Mobile Main Menu: Use the chevron component instead of arrow right

### DIFF
--- a/src/molecules/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/molecules/Breadcrumbs/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ArrowRightIcon } from '../../atoms/Icon/icons';
+import { ChevronRightIcon } from '../../atoms/Icon/icons';
 import { MoreLowIcon } from '../../atoms/Icon/icons';
 
 export interface Crumb {
@@ -203,7 +203,7 @@ const Breadcrumbs = (props: {
           {crumb.name}
         </a>
         {crumb.arrowRight === 'arrow' && (
-          <ArrowRightIcon className={getStyle('telia-breadcrumbs__arrow-right-icon', iconColor)} />
+          <ChevronRightIcon className={getStyle('telia-breadcrumbs__arrow-right-icon', iconColor)} />
         )}
       </>
     );

--- a/src/molecules/Footer/Footer.tsx
+++ b/src/molecules/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ArrowDownIcon, ArrowUpIcon } from '../..';
+import { ChevronDownIcon, ChevronUpIcon } from '../..';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { library, IconLookup, IconDefinition, findIconDefinition, IconName } from '@fortawesome/fontawesome-svg-core';
 import { fab } from '@fortawesome/free-brands-svg-icons';
@@ -75,7 +75,7 @@ const buildColumnsTopRow = (links: LinkColumn | null) => {
           <div className={'telia-footer__accordion-heading'}>
             {links?.heading && <Heading heading={links?.heading} aria-label={links.heading} />}
             <div className={'telia-footer__accordian-chevron'}>
-              {isActive ? <ArrowUpIcon style={{ height: '1em' }} /> : <ArrowDownIcon style={{ height: '1em' }} />}
+              {isActive ? <ChevronUpIcon style={{ height: '1em' }} /> : <ChevronDownIcon style={{ height: '1em' }} />}
             </div>
           </div>
           <div className={'telia-footer__accordion-small-screen'}>

--- a/src/molecules/Menu/MobileMenu/MobileMenuItemWithDropdown.jsx
+++ b/src/molecules/Menu/MobileMenu/MobileMenuItemWithDropdown.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { ArrowDownIcon } from '../../../atoms/Icon';
+import { ChevronDownIcon } from '../../../atoms/Icon';
 
 import MobileSubmenu from './MobileSubmenu';
 
@@ -11,7 +11,7 @@ const MobileMenuItemWithDropdown = ({ link, onItemSelected, LinkTemplate }) => {
   return (
     <div className="menu__mobile-dropdown-menu" onClick={() => setIsExpanded(!isExpanded)}>
       <button className="menu__mobile-dropdown-menu__arrow-button" onClick={() => setIsExpanded(!isExpanded)}>
-        <ArrowDownIcon className={`menu__mobile-dropdown-menu__arrow-icon ${isExpandedClass}`} />
+        <ChevronDownIcon className={`menu__mobile-dropdown-menu__arrow-icon ${isExpandedClass}`} />
       </button>
       <span className="menu__mobile-dropdown-menu__header">{link.text}</span>
       {isExpanded && <MobileSubmenu link={link} onItemSelected={onItemSelected} LinkTemplate={LinkTemplate} />}


### PR DESCRIPTION
- arrow right was previously chevron, but latest Icons from voca has changed it