### PR TITLE
Add dataTrackingID to the Header component

### DIFF
--- a/src/molecules/Header/Header.d.ts
+++ b/src/molecules/Header/Header.d.ts
@@ -15,6 +15,7 @@ export interface HeaderProps {
   withBorderBottom?: boolean;
   backgroundColor?: HeaderBackgroundColor;
   children?: React.ReactNode;
+  dataTrackingId?: string;
 }
 
 export const Header: React.FC<HeaderProps>;

--- a/src/molecules/Header/Header.jsx
+++ b/src/molecules/Header/Header.jsx
@@ -21,6 +21,7 @@ const Header = ({
   withBorderBottom,
   backgroundColor,
   children,
+  dataTrackingId,
 }) => (
   <header
     className={classNames('header', {
@@ -30,6 +31,7 @@ const Header = ({
       'header--with-border-bottom': withBorderBottom,
       [`header--${backgroundColor}`]: !!backgroundColor,
     })}
+    data-tracking-id={dataTrackingId}
   >
     {videoSrc ? (
       <div className="video container container--large container--no-padding container--no-margin">


### PR DESCRIPTION
Task NOCT-27694 requires `data-tracking-id` for various components and one of them is Header component. 
With this PR: 
- added the `dataTrackingID` prop to the Header component
- added the `data-tracking-id` attribute to the header element in the Header component