### PR TITLE
Fix type declaration for Paragraph, BoxGrid and Subscription

### DIFF
--- a/src/atoms/Paragraph/Paragraph.d.ts
+++ b/src/atoms/Paragraph/Paragraph.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 export type ParagraphKind = 'fineprint' | 'preamble';
 
-export interface ParagraphProps {
+export interface ParagraphProps extends React.HTMLAttributes<HTMLParagraphElement> {
   /**
    * One of 'fineprint' or 'preamble'.
    */

--- a/src/molecules/BoxGrid/BoxGrid.d.ts
+++ b/src/molecules/BoxGrid/BoxGrid.d.ts
@@ -1,5 +1,9 @@
 import * as React from 'react';
 
-export const BoxGrid: React.FC;
+export interface BoxGrid {
+  className?: string;
+}
+
+export const BoxGrid: React.FC<BoxGrid>;
 
 export default BoxGrid;

--- a/src/molecules/Subscription/Subscription.d.ts
+++ b/src/molecules/Subscription/Subscription.d.ts
@@ -60,6 +60,7 @@ declare interface SubscriptionProps {
   scrollToOnOpen?: boolean;
   onSelect?: (...args: any[]) => any;
   onClose?: (...args: any[]) => any;
+  isSelected: boolean;
 }
 
 declare const Subscription: React.FC<SubscriptionProps>;


### PR DESCRIPTION
For Paragraph: We would like to use `id`
For BoxGrid: Added `className`
For Subscription: Added `isSelected`