### PR TITLE
Bug: mobile menu redirects upon first clicking the "menu"

### DIFF
--- a/src/molecules/Menu/MobileMenu/MobileMenuHeader.jsx
+++ b/src/molecules/Menu/MobileMenu/MobileMenuHeader.jsx
@@ -17,7 +17,12 @@ const MobileMenuCloseButton = ({ onClick, mobileMenuCloseButtonLabel, value = 'L
 const MobileMenuHeaderItem = ({ index, onHeaderItemSelected, menuLink, isActive, LinkTemplate }) => (
   <li>
     <div
-      onClick={() => onHeaderItemSelected(index)}
+      onClick={(e) => {
+        if (!isActive) {
+          e.preventDefault();
+        }
+        onHeaderItemSelected(index);
+      }}
       tabIndex="0"
       className={classnames('menu__mobile-heading-item', {
         'menu__mobile-heading-item--active': isActive,


### PR DESCRIPTION
- added a fix that if one navigates between the Headings on mobile, it first just runs the "ItemSelected" without using the default rule of a tag (navigating)
- note: might be scenarios where one wants to follow the link on first click, but I have not seen any yet....