### PR TITLE
business/add higher contrast and make hover more visible for black tabs

### DIFF
--- a/src/business/Tabs/Tabs.pcss
+++ b/src/business/Tabs/Tabs.pcss
@@ -22,7 +22,7 @@
     & > a,
     & > button {
       text-decoration: none;
-      color: var(--grey-500);
+      color: var(--grey-700);
       font-size: 16px;
       line-height: 20px;
       font-weight: 500;
@@ -162,6 +162,24 @@
     & > a:hover,
     & > button:hover:before {
       color: var(--black);
+    }
+  }
+}
+
+.telia-tabs--dotted {
+  & > ul > li {
+    /* needed to avoid a solid bottom border glitch when hovering different li's */
+    border-bottom: 2px dotted transparent;
+    &:hover {
+      border-bottom: 2px dotted black;
+    }
+
+    &.active {
+      border-bottom-style: solid;
+    }
+
+    &.active:hover {
+      border-bottom: 2px solid var(--black);
     }
   }
 }

--- a/src/business/Tabs/Tabs.tsx
+++ b/src/business/Tabs/Tabs.tsx
@@ -24,6 +24,7 @@ export const Tabs: React.FC<Props> = (props) => {
           'telia-tabs--narrow': props.narrow,
           'telia-tabs--centered': props.centered,
           'telia-tabs--black': props.color === 'black',
+          'telia-tabs--dotted': props.color === 'black' && !props.outlined,
           'telia-tabs--compact': props.compact,
         },
         props.className


### PR DESCRIPTION
The black version should have a dotted underline on hover
The outline & black version should work as before