### PR TITLE
fix(Modal): disable clickOutsideListener in case of fullscreen Modal

### DIFF
--- a/src/molecules/Modal/Modal.tsx
+++ b/src/molecules/Modal/Modal.tsx
@@ -33,7 +33,8 @@ export const Modal: React.FC<Props> = (props) => {
   const { container } = useFocusTrap();
   const closeModal = () => props.setOpen(false);
   useEscapeListener({ onEscape: closeModal });
-  useClickOutsideListener({ open: props.open, setOpen: props.setOpen, containerRef: container });
+  if (props.size !== 'fullscreen')
+    useClickOutsideListener({ open: props.open, setOpen: props.setOpen, containerRef: container });
   const modalPortal = getModalRoot();
   const size = props.size || 'medium';
 


### PR DESCRIPTION
bugfix: On small screens, any click inside our outside the modal would close it, when it's fullscreen modal.
When size of the modal is fullscreen, we don't need that listener, so I disabled it. 