### PR TITLE
SubscriptionCompactAccordion: Support purple variant

### DIFF
--- a/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.pcss
+++ b/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.pcss
@@ -39,6 +39,11 @@
     line-height: 1.25rem;
     text-align: left;
     width: 100%;
+
+    &--black,
+    &--purple {
+      color: var(--white);
+    }
   }
 
   &__footer-container {
@@ -226,16 +231,42 @@
     transition: border 150ms ease-out;
     padding: 0rem 1rem 1rem 1rem;
 
-    &--inverted {
+    &--black {
       border-left: 3px solid var(--black);
       border-right: 3px solid var(--black);
     }
+
+    &--purple {
+      border-left: 3px solid #4e0174;
+      border-right: 3px solid #4e0174;
+    }
   }
 
-  &--inverted {
+  &--black {
     .subscription-compact-accordion__header-first-row,
     .subscription-compact-accordion__container-button {
       background-color: var(--black);
+      color: var(--white);
+      position: relative;
+
+      &:hover,
+      &:focus {
+        outline: none;
+        cursor: pointer;
+      }
+    }
+
+    .subscription-compact-accordion__icon-arrow,
+    .subscription-compact-accordion__heading-name,
+    .subscription-compact-accordion__heading-striketrough {
+      color: var(--white);
+    }
+  }
+
+  &--purple {
+    .subscription-compact-accordion__header-first-row,
+    .subscription-compact-accordion__container-button {
+      background-color: #4e0174;
       color: var(--white);
       position: relative;
 
@@ -282,7 +313,7 @@
       font-weight: bold;
     }
 
-    &--inverted {
+    &--black {
       color: var(--grey);
     }
   }
@@ -300,11 +331,18 @@
     border-right: 3px solid transparent;
     transition: border 150ms ease-out;
 
-    &--inverted {
+    &--black {
       background-color: var(--black);
       border-left: 3px solid var(--black);
       border-right: 3px solid var(--black);
       border-bottom: 3px solid var(--black);
+    }
+
+    &--purple {
+      background-color: #4e0174;
+      border-left: 3px solid #4e0174;
+      border-right: 3px solid #4e0174;
+      border-bottom: 3px solid #4e0174;
     }
   }
 

--- a/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.stories.tsx
+++ b/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.stories.tsx
@@ -214,27 +214,6 @@ export const WithAll = () => {
   );
 };
 
-export const Inverted = () => {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  return (
-    <SubscriptionCompactAccordion
-      id="smart20"
-      name="Telia X - Normal"
-      title="40 Mbit/s"
-      strikethrough="20 Mbit/s"
-      price={499}
-      priceInfo={['/md.']}
-      isInverted={true}
-      isExpanded={isExpanded}
-      scrollToOnOpen={true}
-      onOpen={() => setIsExpanded(!isExpanded)}
-    >
-      {CHILDREN}
-    </SubscriptionCompactAccordion>
-  );
-};
-
 export const Multiple = () => {
   const [expandedSubscriptionIndex, setExpandedSubscriptionIndex] = useState(-1);
 
@@ -255,5 +234,48 @@ export const Multiple = () => {
         </SubscriptionCompactAccordion>
       ))}
     </>
+  );
+};
+
+export const Black = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <SubscriptionCompactAccordion
+      id="smart20"
+      name="Telia X - Normal"
+      title="40 Mbit/s"
+      strikethrough="20 Mbit/s"
+      price={499}
+      priceInfo={['/md.']}
+      isExpanded={isExpanded}
+      scrollToOnOpen={true}
+      onOpen={() => setIsExpanded(!isExpanded)}
+      variant="black"
+    >
+      {CHILDREN}
+    </SubscriptionCompactAccordion>
+  );
+};
+
+export const Purple = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <SubscriptionCompactAccordion
+      name="Telia X - Normal"
+      title="20 Mbit/s"
+      id="smart20"
+      price={499}
+      strikethrough="10 Mbit/s"
+      priceInfo={['/md.']}
+      isExpanded={isExpanded}
+      onOpen={() => {
+        setIsExpanded(!isExpanded);
+      }}
+      variant="purple"
+    >
+      {CHILDREN}
+    </SubscriptionCompactAccordion>
   );
 };

--- a/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.tsx
+++ b/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.tsx
@@ -14,7 +14,6 @@ interface Ribbon {
 export interface SubscriptionCompactAccordionProps {
   id?: string;
   isExpanded?: boolean;
-  isInverted?: boolean;
   name: string;
   title: string;
   strikethrough?: string;
@@ -32,12 +31,12 @@ export interface SubscriptionCompactAccordionProps {
   style?: React.CSSProperties;
   footer?: React.ReactNode;
   children?: React.ReactNode;
+  variant?: 'black' | 'purple';
 }
 
 const SubscriptionCompactAccordion = ({
   id,
   isExpanded,
-  isInverted,
   name,
   title,
   strikethrough,
@@ -55,6 +54,7 @@ const SubscriptionCompactAccordion = ({
   className,
   onOpen = () => {},
   style,
+  variant,
 }: SubscriptionCompactAccordionProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -73,7 +73,8 @@ const SubscriptionCompactAccordion = ({
       ref={ref}
       id={id}
       className={cn('subscription-compact-accordion', className, {
-        'subscription-compact-accordion--inverted': isInverted,
+        'subscription-compact-accordion--black': variant === 'black',
+        'subscription-compact-accordion--purple': variant === 'purple',
       })}
     >
       <button
@@ -95,7 +96,14 @@ const SubscriptionCompactAccordion = ({
               {ribbon.text}
             </div>
           ) : null}
-          <div className="subscription-compact-accordion__name">{name}</div>
+          <div
+            className={cn('subscription-compact-accordion__name', {
+              'subscription-compact-accordion__name--black': variant === 'black',
+              'subscription-compact-accordion__name--purple': variant === 'purple',
+            })}
+          >
+            {name}
+          </div>
           <div className="subscription-compact-accordion__header-first-row">
             <div className="subscription-compact-accordion__left-side subscription-compact-accordion__flex--grow">
               <div className="subscription-compact-accordion__heading-container">
@@ -169,7 +177,8 @@ const SubscriptionCompactAccordion = ({
       {isExpanded && children && (
         <section
           className={cn('subscription-compact-accordion__expanded-info', {
-            'subscription-compact-accordion__expanded-info--inverted': isInverted,
+            'subscription-compact-accordion__expanded-info--black': variant === 'black',
+            'subscription-compact-accordion__expanded-info--purple': variant === 'purple',
           })}
         >
           {children}
@@ -177,7 +186,8 @@ const SubscriptionCompactAccordion = ({
       )}
       <div
         className={cn('subscription-compact-accordion__footer-border', {
-          'subscription-compact-accordion__footer-border--inverted': isInverted,
+          'subscription-compact-accordion__footer-border--black': variant === 'black',
+          'subscription-compact-accordion__footer-border--purple': variant === 'purple',
         })}
       />
     </section>


### PR DESCRIPTION
https://trello.com/c/FVGv2weA/2960-make-ung-subscription-purple-background

- Removed `isInverted` prop and replaced it with a more general `variant` prop to also support purple variant. According to my research, webshop is the only team using the component and we don't actually use the inverted variant at the moment, so it should be fine.

![image](https://github.com/TeliaSoneraNorge/styleguide/assets/11172530/68b6dff3-b76b-4471-9173-f743701e4e53)
![image](https://github.com/TeliaSoneraNorge/styleguide/assets/11172530/9369ff86-ace3-4c11-bcd3-ba79803333e4)
