### PR TITLE
Setting activeIndex to 'activeIndex' prop instead of selectedHeaderIn…

### DIFF
--- a/src/molecules/Menu/Menu.jsx
+++ b/src/molecules/Menu/Menu.jsx
@@ -100,7 +100,9 @@ const Menu = ({
     const focusableElements = mobileMenuRef.current.querySelectorAll(focusableElementsSelector);
     if (!focusableElements.length) return;
 
-    focusableElements[0].focus();
+    if (activeIndex === 0) {
+      focusableElements[0].focus();
+    }
   };
 
   useEffect(setFocusOnFirstFocusableElement);
@@ -128,7 +130,7 @@ const Menu = ({
         LinkTemplate={LinkTemplate}
         onMobileMenuToggle={toggleMobileMenu}
         menuLinks={menuLinks}
-        selectedHeaderIndex={activeIndex}
+        activeIndex={activeIndex}
         onMenuItemSelected={toggleMobileMenu}
         isLoading={isLoading}
         mobileMenuCloseButtonLabel={mobileMenuCloseButtonLabel}

--- a/src/molecules/Menu/Menu.jsx
+++ b/src/molecules/Menu/Menu.jsx
@@ -100,7 +100,7 @@ const Menu = ({
     const focusableElements = mobileMenuRef.current.querySelectorAll(focusableElementsSelector);
     if (!focusableElements.length) return;
 
-    if (activeIndex === 0) {
+    if (!activeIndex || activeIndex === 0) {
       focusableElements[0].focus();
     }
   };

--- a/src/molecules/Menu/Menu.stories.tsx
+++ b/src/molecules/Menu/Menu.stories.tsx
@@ -254,6 +254,118 @@ export const LoggedInDropdownMenuB2C = () => {
   );
 };
 
+export const LoggedInDropdownSelectedSecondMenuLink = () => {
+  const menuLinks = [
+    {
+      heading: {
+        text: 'Privat',
+        url: '/',
+      },
+      links: [
+        {
+          text: 'Nettbutikk',
+          subLinks: [
+            {
+              text: 'Mobiltelefoner',
+              url: '/mobiltelefoner/',
+            },
+            {
+              text: 'Smartklokker',
+              url: '/smartklokker/',
+            },
+            {
+              text: 'Nettbrett',
+              url: '/nettbrett/',
+            },
+          ],
+        },
+        {
+          text: 'Mobilabonnement',
+          url: '/mobilabonnement/',
+        },
+        {
+          text: 'Internett',
+          url: '/internett/',
+        },
+      ],
+    },
+    {
+      heading: {
+        text: 'Bedrift',
+        url: '/bedrift/',
+      },
+      links: [
+        {
+          text: 'Produkter og tjenester',
+          url: '/bedrift/produkter-og-tjenester/',
+        },
+        {
+          text: 'Teknologi og samfunn',
+          subLinks: [
+            {
+              text: 'IoT',
+              url: '/bedrift/digitalisering/iot/',
+            },
+            {
+              text: '5G',
+              url: '/bedrift/5g-bedrift/',
+            },
+            {
+              text: 'Crowd Insights',
+              url: '/bedrift/digitalisering/crowd-insights/',
+            },
+            {
+              text: 'Startup',
+              url: '/bedrift/startup/',
+            },
+            {
+              text: 'Aktuelt',
+              url: '/bedrift/digitalisering/aktuelt/',
+            },
+          ],
+        },
+        {
+          text: 'Nettbutikk',
+          subLinks: [
+            {
+              text: 'Mobiltelefoner',
+              url: 'https://www.telia.no/bedrift/mobiltelefoner/',
+            },
+            {
+              text: 'Mobilabonnement',
+              url: '/bedrift/mobilabonnement/',
+            },
+            {
+              text: 'Mobilt Bredbånd',
+              url: 'https://www.telia.no/bedrift/mobilt-bredband/',
+            },
+          ],
+        },
+        {
+          text: 'Kundeservice',
+          url: '/bedrift/kundeservice/',
+        },
+      ],
+    },
+  ];
+
+  return (
+    <Menu
+      loginUrl="#Menu"
+      logoUrl="#"
+      logoTitle="Telia logo"
+      menuLinks={menuLinks}
+      activeIndex={1}
+      logoImageDesktopPath={img.logo}
+      logoImageInverseDesktopPath={img.logoInverted}
+      onSearchSubmit={() => {}}
+      lockBodyOnMenuOpen={true}
+      isLoggedIn={false}
+      myPageUrl="#"
+    />
+  );
+};
+
 export const LoggedInDropdownMenuWithDaas = () => {
   const menuLinks = [
     {

--- a/src/molecules/Menu/MobileMenu/MobileMenu.jsx
+++ b/src/molecules/Menu/MobileMenu/MobileMenu.jsx
@@ -52,10 +52,11 @@ const MobileMenu = ({
   menuLinks,
   onMenuItemSelected,
   isLoading,
+  activeIndex,
   mobileMenuCloseButtonLabel,
   buttonValues,
 }) => {
-  const [selectedHeaderIndex, setSelectedHeaderIndex] = useState(0);
+  const [selectedHeaderIndex, setSelectedHeaderIndex] = useState(activeIndex ?? 0);
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
…dex which does nada, so it actually selects either "Private" or "Bedrift [Company]" at "page load"

Do not set focus if activeIndex has been set, else you end up with "focus" css rules, which are equal to active index rule, so both seems to be selected Added a story to verify the feature