### PR TITLE
Button: Move style to change specificity

### DIFF
--- a/src/atoms/Button/Button.pcss
+++ b/src/atoms/Button/Button.pcss
@@ -45,15 +45,6 @@
     color: var(--white);
   }
 
-  &--small {
-    padding: 0.6rem 1.3rem;
-  }
-
-  &--xs {
-    padding: 0.5rem 1.3rem;
-    font-size: 0.8rem;
-  }
-
   &--primary {
     background-color: var(--dark-green);
     border: none;
@@ -190,6 +181,15 @@
     &:focus {
       background-color: var(--core-purple-850) !important;
     }
+  }
+
+  &--small {
+    padding: 0.6rem 1.3rem;
+  }
+
+  &--xs {
+    padding: 0.5rem 1.3rem;
+    font-size: 0.8rem;
   }
 
   &__processing {

--- a/src/atoms/Button/Button.stories.tsx
+++ b/src/atoms/Button/Button.stories.tsx
@@ -63,7 +63,7 @@ export const Small = () => (
 
 export const ExtraSmall = () => (
   <>
-    <Button text="Legg til" size="xs" icon="cart" />
+    <Button text="Legg til" kind="voca-purple" size="xs" icon="cart" />
     <Button text="Legg til" kind="primary" size="xs" icon="cart" />
     <Button text="Legg til" isDisabled={true} size="xs" icon="cart" />
   </>


### PR DESCRIPTION
After https://github.com/TeliaSoneraNorge/styleguide/pull/1425, I noticed that when adding `kind="voca-purple"`, the font-size in class `&--voca-normal` will override the font-size in `&--xs`.

I reordered them in the css file to change which takes priority.


| Before  | After  |
|---|---|
|![image](https://github.com/TeliaSoneraNorge/styleguide/assets/11172530/18a0e1c6-3a6c-444b-ac4e-01dd60508c8f)|![image](https://github.com/TeliaSoneraNorge/styleguide/assets/11172530/186739eb-f899-4131-9433-53d26c603ed3)|