### PR TITLE
BigImage D: Remove center align

### DIFF
--- a/src/molecules/BigImageDialog/BigImageDialog.jsx
+++ b/src/molecules/BigImageDialog/BigImageDialog.jsx
@@ -90,7 +90,7 @@ const BigImageDialog = ({
           <img alt="" src={src} />
         </div>
         <div className="big-image-dialog__content">
-          <div className="big-image-dialog__top-heading">{topHeading}</div>
+          <div>{topHeading}</div>
           <h2 id={`${name}-heading`} className="big-image-dialog__heading">
             {heading}
           </h2>

--- a/src/molecules/BigImageDialog/BigImageDialog.pcss
+++ b/src/molecules/BigImageDialog/BigImageDialog.pcss
@@ -126,15 +126,10 @@
     }
   }
 
-  &__top-heading {
-    align-self: start;
-  }
-
   &__content {
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-    align-items: center;
     padding: 4rem 0.75rem 2rem;
   }
 


### PR DESCRIPTION
Removing center align so that topHeading will be aligned left.