### PR TITLE
Fix footer accordions on Android

### DIFF
--- a/src/molecules/Footer/Footer.tsx
+++ b/src/molecules/Footer/Footer.tsx
@@ -3,7 +3,6 @@ import { ChevronDownIcon, ChevronUpIcon } from '../..';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { library, IconLookup, IconDefinition, findIconDefinition, IconName } from '@fortawesome/fontawesome-svg-core';
 import { fab } from '@fortawesome/free-brands-svg-icons';
-import { useMediaQuery } from 'react-responsive';
 
 library.add(fab);
 
@@ -61,15 +60,15 @@ const LinkColumnsRender = (model: { links: LinkColumn[] | null; isBottom: boolea
 
 const buildColumnsTopRow = (links: LinkColumn | null) => {
   const [isActive, setIsActive] = useState(false);
-  const isMobile = useMediaQuery({ query: `(max-width: 54em)` });
 
   return (
     <div className={'telia-footer__nav-column-top'}>
       {links && (
         <button
           className={'telia-footer__accordion'}
-          disabled={!isMobile}
-          onClick={() => setIsActive(!isActive)}
+          onClick={() => {
+            setIsActive(!isActive);
+          }}
           aria-label={links?.heading ? links.heading : ' '}
         >
           <div className={'telia-footer__accordion-heading'}>


### PR DESCRIPTION
https://trello.com/c/3H9wWODP/3382-unresponse-clicks-in-footer-menu

We have many Mediallia recordings showing that the footer links are unclickable on Android phones. Example:

https://github.com/TeliaSoneraNorge/styleguide/assets/11172530/c52acb40-251a-4468-a5f4-e4a79b4d7bb2


This removes the disabled prop completely. It doesn't really matter that it is clickable on desktop as well since it will not expand on desktop.