### PR TITLE
enable css variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,32 @@ We also use the [BEM-pattern](http://getbem.com/naming/): `block__elements--modi
 
 ## Consuming the local, development styleguide in other local web apps
 
-`NOTE: This section was written for the old styleguide and needs revision. Maybe something about npm link?`
+Use `npm link` to test a modified Telia Norge Styleguide component locally in telia-no-min-side project.
 
-1. Install `http-server` globally with npm (https://www.npmjs.com/package/http-server)
-2. Go to you local styleguide folder in your terminal and type `http-server ./ --cors`
-3. Include stylesheet in your project `<link rel="stylesheet" href="http://local-styleguide:8080/css/bundle.components.css">`
+```bash
+#  in Telia Norge Styleguide directory
+npm run build:icons
+npm run build
+cd dist
+npm link
+
+# in your project directory
+npm link @telia/styleguide
+npm start
+```
+
+Now whenever you change anything in Telia Norge Styleguide, rerun `npm run build` and your project should pick up the changes.
+
+When you're finished, unlink the Telia Norge Styleguide:
+
+```bash
+# in your project directory
+npm unlink --no-save @telia/styleguide
+npm install
+
+# in Telia Norge Styleguide directory
+npm unlink -g
+```
 
 #### To publish locally
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -15,6 +15,10 @@ For Major and Minor changes in version you must notify everyone in the #stylegui
 
 Only noteworthy changes.
 
+# 1.56.0
+
+- Enabled CSS variables
+
 # 1.50.0
 
 - Updated React to version 18

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
         "postcss": "8.4.31",
         "postcss-calc": "7.0.1",
         "postcss-cli": "6.1.1",
-        "postcss-custom-properties": "8.0.9",
         "postcss-easy-import": "3.0.0",
         "postcss-functions": "3.0.0",
         "postcss-hexrgba": "^1.0.2",
@@ -25153,45 +25152,6 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      }
-    },
-    "node_modules/postcss-custom-properties": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.9.tgz",
-      "integrity": "sha512-/Lbn5GP2JkKhgUO2elMs4NnbUJcvHX4AaF5nuJDaNkd2chYW1KA5qtOGGgdkBEWcXtKSQfHXzT7C6grEVyb13w==",
-      "dev": true,
-      "dependencies": {
-        "postcss": "^7.0.5",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/postcss-custom-properties/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dev": true,
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-custom-properties/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/postcss-easy-import": {
@@ -50373,34 +50333,6 @@
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
           }
-        }
-      }
-    },
-    "postcss-custom-properties": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-8.0.9.tgz",
-      "integrity": "sha512-/Lbn5GP2JkKhgUO2elMs4NnbUJcvHX4AaF5nuJDaNkd2chYW1KA5qtOGGgdkBEWcXtKSQfHXzT7C6grEVyb13w==",
-      "dev": true,
-      "requires": {
-        "postcss": "^7.0.5",
-        "postcss-values-parser": "^2.0.0"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.39",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-          "dev": true,
-          "requires": {
-            "picocolors": "^0.2.1",
-            "source-map": "^0.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "postcss": "8.4.31",
     "postcss-calc": "7.0.1",
     "postcss-cli": "6.1.1",
-    "postcss-custom-properties": "8.0.9",
     "postcss-easy-import": "3.0.0",
     "postcss-functions": "3.0.0",
     "postcss-hexrgba": "^1.0.2",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -29,9 +29,6 @@ module.exports = {
       },
     },
     'postcss-nested': {},
-    'postcss-custom-properties': {
-      preserve: false,
-    },
     'postcss-calc': {},
     'postcss-replace': {
       data: {

--- a/src/molecules/DatePicker/Accessories.tsx
+++ b/src/molecules/DatePicker/Accessories.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 import { Avatar, Icon } from '../../index';
 
-export const Calendar = (props: { onClick: () => void }) => (
-  <Avatar icon="calendar" onClick={props.onClick} size="compact" color="transparent" />
-);
+export const Calendar = (props: { onClick: () => void }) => {
+  const onClick = (e: React.SyntheticEvent) => {
+    e.preventDefault();
+    props.onClick();
+  };
+
+  return <Avatar icon="calendar" onClick={onClick} size="compact" color="transparent" />;
+};
+
 export const Arrow = () => <Icon icon="arrow-right" style={{ height: '1.25rem', width: '1.25rem' }} />;

--- a/src/molecules/DatePicker/DataPicker.pcss
+++ b/src/molecules/DatePicker/DataPicker.pcss
@@ -1,4 +1,9 @@
 .telia-date-picker {
+  --date-picker-period-input-border-radius: 4px;
+  --date-picker-period-input-border-color: var(--grey-400);
+  --date-picker-period-input-border-color-focused: var(--core-purple-500);
+  --date-picker-menu-border-radius: 4px;
+
   position: relative;
   input[type='text'],
   input[type='time'] {
@@ -30,6 +35,10 @@
 }
 .telia-date-picker__input {
   width: 200px;
+
+  &.telia-date-picker__input--full-width {
+    width: 100%;
+  }
 }
 .telia-date-picker__period {
   .telia-date-picker__inputs {
@@ -40,7 +49,7 @@
     .telia-textfield__input {
       transition: border 200ms;
 
-      border: 1px solid var(--grey-400);
+      border: 1px solid var(--date-picker-period-input-border-color);
       border-right-color: transparent;
       border-top-right-radius: 0px;
       border-bottom-right-radius: 0px;
@@ -62,8 +71,8 @@
         position: absolute;
         width: 1px;
         height: 38px;
-        border-top: 1px solid var(--grey-400);
-        border-bottom: 1px solid var(--grey-400);
+        border-top: 1px solid var(--date-picker-period-input-border-color);
+        border-bottom: 1px solid var(--date-picker-period-input-border-color);
       }
       &::after {
         right: 0;
@@ -73,9 +82,9 @@
 
     > *:first-child {
       .telia-textfield__input {
-        border-top-left-radius: 4px;
-        border-bottom-left-radius: 4px;
-        border-color: var(--grey-400);
+        border-top-left-radius: var(--date-picker-period-input-border-radius);
+        border-bottom-left-radius: var(--date-picker-period-input-border-radius);
+        border-color: var(--date-picker-period-input-border-color);
         border-right-color: transparent;
       }
       &::before {
@@ -85,13 +94,13 @@
 
     > *:last-child {
       .telia-textfield__rightContent {
-        border-right: 1px solid var(--grey-400);
-        border-top-right-radius: 4px;
-        border-bottom-right-radius: 4px;
+        border-right: 1px solid var(--date-picker-period-input-border-color);
+        border-top-right-radius: var(--date-picker-period-input-border-radius);
+        border-bottom-right-radius: var(--date-picker-period-input-border-radius);
       }
 
       .telia-textfield__input {
-        border: 1px solid var(--grey-400);
+        border: 1px solid var(--date-picker-period-input-border-color);
         border-left-color: transparent;
         border-right-color: transparent;
       }
@@ -107,15 +116,15 @@
 
   .telia-textfield__rightContent {
     transition: border 200ms;
-    border-top: 1px solid var(--grey-400);
-    border-bottom: 1px solid var(--grey-400);
+    border-top: 1px solid var(--date-picker-period-input-border-color);
+    border-bottom: 1px solid var(--date-picker-period-input-border-color);
     border-radius: 0;
     margin-left: -1px;
   }
   .telia-textfield__input {
     transition: border 200ms;
 
-    border: 1px solid var(--grey-400);
+    border: 1px solid var(--date-picker-period-input-border-color);
     border-right-color: transparent;
     border-top-right-radius: 0px;
     border-bottom-right-radius: 0px;
@@ -123,7 +132,7 @@
 
   .telia-textfield__focus {
     .telia-textfield__input {
-      border-color: var(--core-purple-500);
+      border-color: var(--date-picker-period-input-border-color-focused);
     }
     .telia-textfield__rightContent {
       margin: 0;
@@ -131,12 +140,12 @@
   }
   .telia-date-picker__input.telia-textfield__focus {
     .telia-textfield__input {
-      border-color: var(--core-purple-500);
+      border-color: var(--date-picker-period-input-border-color-focused);
     }
 
     &::before,
     &::after {
-      border-color: var(--core-purple-500);
+      border-color: var(--date-picker-period-input-border-color-focused);
     }
   }
 }
@@ -145,7 +154,7 @@
   position: absolute;
   background-color: white;
   box-shadow: 0px 8px 32px rgba(58, 58, 58, 0.18);
-  border-radius: 4px;
+  border-radius: var(--menu-border-radius);
   z-index: 10;
   min-width: 350px;
   &--options {

--- a/src/molecules/DatePicker/DatePicker.stories.tsx
+++ b/src/molecules/DatePicker/DatePicker.stories.tsx
@@ -22,6 +22,7 @@ export const Default = () => {
   const [date4, setDate4] = useState<string | undefined>('2020-05-01');
   const [date5, setDate5] = useState<string | undefined>(undefined);
   const [date6, setDate6] = useState<string | undefined>(undefined);
+  const [date7, setDate7] = useState<string | undefined>(undefined);
 
   return (
     <div style={{ width: '30%', margin: '2rem', display: 'flex', flexDirection: 'column' }}>
@@ -55,6 +56,11 @@ export const Default = () => {
       <div style={{ marginTop: '2rem ' }}>
         <div>Custom day labels</div>
         <DatePicker value={date6} onSelectDate={setDate6} dayLabels={['M', 'T', 'W', 'T', 'F', 'S', 'S']} />
+      </div>
+
+      <div style={{ marginTop: '2rem ' }}>
+        <div>Full width</div>
+        <DatePicker value={date7} onSelectDate={setDate7} fullWidth />
       </div>
     </div>
   );

--- a/src/molecules/DatePicker/DatePicker.tsx
+++ b/src/molecules/DatePicker/DatePicker.tsx
@@ -17,8 +17,15 @@ export const DatePicker = (props: DatePickerProps) => {
               placeholder={props.inputPlaceholder}
               min={props.minDate}
               max={props.maxDate}
+              fullWidth={props.fullWidth}
               rightContent={<Calendar onClick={() => contextValue.setCalendarOpen(!contextValue.calendarOpen)} />}
               label={props.label ?? 'Velg dato'}
+              error={props.error}
+              helpText={props.helpText}
+              required={props.required}
+              disabled={props.disabled}
+              name={props.name}
+              inputRef={props.inputRef}
             />
 
             <DatePickerMenu />

--- a/src/molecules/DatePicker/DatePickerDay.tsx
+++ b/src/molecules/DatePicker/DatePickerDay.tsx
@@ -59,6 +59,7 @@ export const DatePickerDay = (props: Props) => {
       })}
       onClick={selectDate}
       disabled={disabled}
+      type="button"
     >
       {props.day}
     </button>

--- a/src/molecules/DatePicker/DatePickerInput.tsx
+++ b/src/molecules/DatePicker/DatePickerInput.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import React from 'react';
+import React, { MutableRefObject, RefObject } from 'react';
 import { TextField } from '../TextField';
 import { useDatePicker } from './context';
 
@@ -13,6 +13,13 @@ export type Props = {
   placeholder?: string;
   max?: string;
   min?: string;
+  fullWidth?: boolean;
+  error?: boolean;
+  helpText?: React.ReactNode;
+  name?: string;
+  required?: boolean;
+  disabled?: boolean;
+  inputRef?: RefObject<HTMLInputElement> | MutableRefObject<HTMLInputElement>;
 };
 export const DatePickerInput = (props: Props) => {
   const { setCalendarOpen, isMobile } = useDatePicker();
@@ -59,7 +66,10 @@ export const DatePickerInput = (props: Props) => {
   };
   return (
     <TextField
-      className={cn('telia-date-picker__input', { 'telia-date-picker__input--compact': isMobile })}
+      className={cn('telia-date-picker__input', {
+        'telia-date-picker__input--compact': isMobile,
+        'telia-date-picker__input--full-width': props.fullWidth,
+      })}
       placeholder={props.placeholder ?? 'dd.mm.åååå'}
       type="text"
       value={input}
@@ -69,6 +79,12 @@ export const DatePickerInput = (props: Props) => {
       rightContent={props.rightContent}
       label={props.label}
       onFocus={() => setCalendarOpen(true)}
+      error={props.error}
+      helpText={props.helpText}
+      name={props.name}
+      required={props.required}
+      disabled={props.disabled}
+      inputRef={props.inputRef}
     />
   );
 };

--- a/src/molecules/DatePicker/types.ts
+++ b/src/molecules/DatePicker/types.ts
@@ -1,3 +1,5 @@
+import { MutableRefObject, RefObject } from 'react';
+
 type CommonProps = {
   size?: 'compact' | 'default';
 
@@ -8,13 +10,13 @@ type CommonProps = {
 
   /**
    * ordered array of label for months, from january-december
-   * @default "Norwegain full name. ['Januar','Februar','Mars','April','Mai','Juni','Juli','August','September','Oktober','November','Desember'];"
+   * @default "Norwegian full name. ['Januar','Februar','Mars','April','Mai','Juni','Juli','August','September','Oktober','November','Desember'];"
    */
   monthLabels?: Array<string>;
 
   /**
    * ordered array of label for months, from january-december
-   * @default "Norwgian short name. ['Ma', 'Ti', 'On', 'To', 'Fr', 'Lø', 'Sø']"
+   * @default "Norwegian short name. ['Ma', 'Ti', 'On', 'To', 'Fr', 'Lø', 'Sø']"
    */
   dayLabels?: Array<string>;
 
@@ -37,6 +39,22 @@ type CommonProps = {
    */
   open?: boolean;
   setOpen?: (open: boolean) => void;
+  /**
+   * If `true`, the outline and helptext will be displayed in an error state.
+   * @default false
+   */
+  error?: boolean;
+  /**
+   * The help text content displayed under the input
+   */
+  helpText?: React.ReactNode;
+  /**
+   * Expand the datepicker input field to fit the parent container
+   */
+  name?: string;
+  fullWidth?: boolean;
+  required?: boolean;
+  disabled?: boolean;
 };
 
 export type PeriodPickerProps = CommonProps & {
@@ -90,4 +108,5 @@ export type DatePickerProps = CommonProps & {
    * @default today
    */
   value?: string;
+  inputRef?: RefObject<HTMLInputElement> | MutableRefObject<HTMLInputElement>;
 };

--- a/src/molecules/TextField/TextField.pcss
+++ b/src/molecules/TextField/TextField.pcss
@@ -1,21 +1,53 @@
 .telia-textfield {
+  --text-input-default-background-color: var(--white);
+  --text-input-default-border-color: var(--grey-300);
+  --text-input-default-padding: 0.75rem;
+  --text-input-default-text-color: var(--grey-900);
+  --text-input-default-text-size: 16px;
+  --text-input-default-placeholder-color: var(--grey-400);
+  --text-input-default-label-color: var(--grey-900);
+  --text-input-default-label-font-size: 14px;
+  --text-input-default-label-font-weight: inherit;
+  --text-input-default-label-margin-bottom: 0;
+  --text-input-default-help-text-color: var(--grey-700);
+  --text-input-default-help-text-font-size: inherit;
+  --text-input-default-help-text-margin-top: 0;
+  --text-input-empty-border-color: var(--grey-200);
+  --text-input-empty-text-color: var(--grey-500);
+  --text-input-hover-border-color: var(--grey-300);
+  --text-input-focus-border-color: var(--core-purple-500);
+  --text-input-success-border-color: var(--green-600);
+  --text-input-success-label-color: var(--green-600);
+  --text-input-success-help-text-color: var(--green-600);
+  --text-input-success-status-color: var(--green-600);
+  --text-input-error-border-color: var(--red-600);
+  --text-input-error-label-color: var(--red-600);
+  --text-input-error-help-text-color: var(--red-600);
+  --text-input-error-status-color: var(--red-600);
+  --text-input-disabled-background-color: var(--grey-100);
+  --text-input-disabled-border-color: var(--grey-200);
+  --text-input-disabled-text-color: var(--grey-300);
+  --text-input-disabled-label-color: var(--grey-400);
+  --text-input-compact-text-size: 14px;
+  --text-input-border-radius: 4px;
+
   position: relative;
   input {
     flex-grow: 1;
-    padding: 0.75rem;
-    font-size: 16px;
+    padding: var(--text-input-default-padding);
+    font-size: var(--text-input-default-text-size);
     line-height: 20px;
     border: none;
-    border-radius: 4px;
+    border-radius: var(--text-input-border-radius);
     margin: 0;
     min-width: 0;
-    color: var(--grey-500);
-    background-color: var(--white);
+    color: var(--text-input-empty-text-color);
+    background-color: var(--text-input-default-background-color);
     &:focus {
       outline: none;
     }
     &::placeholder {
-      color: var(--grey-400);
+      color: var(--text-input-default-placeholder-color);
     }
   }
 
@@ -35,26 +67,29 @@
 }
 
 .telia-textfield__label {
-  font-size: 14px;
-  color: var(--grey-900);
+  font-size: var(--text-input-default-label-font-size);
+  font-weight: var(--text-input-default-label-font-weight);
+  color: var(--text-input-default-label-color);
+  margin-bottom: var(--text-input-default-label-margin-bottom);
+  display: inline-block;
 }
 
 .telia-textfield__content {
   display: flex;
-  background-color: var(--white);
-  border: 1px solid var(--grey-200);
-  border-radius: 4px;
+  background-color: var(--text-input-default-background-color);
+  border: 1px solid var(--text-input-empty-border-color);
+  border-radius: var(--text-input-border-radius);
   transition-duration: 300ms;
   transition-property: border;
 
   &:hover {
-    border-color: var(--grey-300);
+    border-color: var(--text-input-hover-border-color);
   }
 }
 
 .telia-textfield--withValue .telia-textfield__content {
-  border-color: var(--grey-300);
-  color: var(--grey-900);
+  border-color: var(--text-input-default-border-color);
+  color: var(--text-input-default-text-color);
 }
 
 .telia-textfield__status {
@@ -64,7 +99,7 @@
   justify-content: center;
   width: 40px;
   height: 40px;
-  background-color: var(--white);
+  background-color: var(--text-input-default-background-color);
   .Icon {
     width: 20px;
     height: 20px;
@@ -78,16 +113,16 @@
   justify-content: center;
   min-width: 40px;
   flex-shrink: 0;
-  background-color: var(--white);
+  background-color: var(--text-input-default-background-color);
 }
 .telia-textfield__leftContent {
-  border-top-left-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-top-left-radius: var(--text-input-border-radius);
+  border-bottom-left-radius: var(--text-input-border-radius);
 }
 .telia-textfield__status,
 .telia-textfield__rightContent {
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
+  border-top-right-radius: var(--text-input-border-radius);
+  border-bottom-right-radius: var(--text-input-border-radius);
 }
 
 .telia-textfield__leftContent > .Icon,
@@ -97,56 +132,58 @@
 }
 
 .telia-textfield__helptext {
-  color: var(--grey-700);
+  color: var(--text-input-default-help-text-color);
+  font-size: var(--text-input-default-help-text-font-size);
   display: block;
+  margin-top: var(--text-input-default-help-text-margin-top);
 }
 
 .telia-textfield--focus {
   .telia-textfield__content {
-    border-color: var(--core-purple-500);
+    border-color: var(--text-input-focus-border-color);
     transition: all 150ms ease-in-out;
   }
 }
 
 .telia-textfield--error {
   .telia-textfield__content {
-    border-color: var(--red-600);
+    border-color: var(--text-input-error-border-color);
   }
   .telia-textfield__status {
-    color: var(--red-600);
+    color: var(--text-input-error-status-color);
   }
   .telia-textfield__helptext {
-    color: var(--red-600);
+    color: var(--text-input-error-help-text-color);
   }
 }
 .telia-textfield--success {
   .telia-textfield__content {
-    border-color: var(--green-600);
+    border-color: var(--text-input-success-border-color);
   }
   .telia-textfield__status {
-    color: var(--green-600);
+    color: var(--text-input-success-status-color);
   }
   .telia-textfield__helptext {
-    color: var(--green-600);
+    color: var(--text-input-success-help-text-color);
   }
 }
 
 .telia-textfield--disabled {
   .telia-textfield__label,
   .telia-textfield__helptext {
-    color: var(--grey-400);
+    color: var(--text-input-disabled-label-color);
   }
   .telia-textfield__content {
-    background-color: var(--grey-100);
-    border: 1px solid var(--grey-200);
+    background-color: var(--text-input-disabled-background-color);
+    border: 1px solid var(--text-input-disabled-border-color);
     input:disabled {
-      color: var(--grey-300);
-      background-color: var(--grey-100);
+      color: var(--text-input-disabled-text-color);
+      background-color: var(--text-input-disabled-background-color);
     }
   }
   .telia-textfield__leftContent,
   .telia-textfield__rightContent {
-    background-color: var(--grey-100);
+    background-color: var(--text-input-disabled-background-color);
   }
   .Icon {
     fill: var(--grey-300);
@@ -155,23 +192,10 @@
 
 .telia-textfield--compact {
   margin-top: 8px;
-  font-size: 14px;
+  font-size: var(--text-input-compact-text-size);
 
   .telia-textfield__label {
-    font-size: 14px;
-    /*
-    Don't need the commented-out code after a design update on the compact label.
-    In case of changing back, keep this a couple of months
-    position: absolute;
-    left: 0.75rem;
-    cursor: text;
-    line-height: 20px;
-    top: 10px;
-    color: var(--grey-400);
-    transition-property: font-size, top, left, color;
-    transition-duration: 200ms;
-    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-    */
+    font-size: var(--text-input-default-label-font-size);
   }
 
   input {
@@ -193,44 +217,17 @@
   }
 }
 
-/*
-Don't need this after a design update on the compact label.
-In case of changing back, keep this a couple of months
-.telia-textfield--compact.telia-textfield--focus,
-.telia-textfield--compact.telia-textfield--withValue {
-  .telia-textfield__label {
-    background: white;
-    top: -6px;
-    left: 7px;
-    line-height: 12px;
-    font-size: 12px;
-    padding: 0px 3px;
-    color: var(--core-purple-500);
-
-    transition-property: font-size, top, left, color;
-    transition-duration: 200ms;
-    transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
-  }
-}
-
-.telia-textfield--compact.telia-textfield--withValue:not(.telia-textfield--focus) {
-  .telia-textfield__label {
-    color: var(--grey-400);
-  }
-}
-*/
-
 .telia-textfield--compact.telia-textfield--focus.telia-textfield--success,
 .telia-textfield--compact.telia-textfield--withValue.telia-textfield--success {
   .telia-textfield__label {
-    color: var(--green-600);
+    color: var(--text-input-success-label-color);
   }
 }
 
 .telia-textfield--compact.telia-textfield--focus.telia-textfield--error,
 .telia-textfield--compact.telia-textfield--withValue.telia-textfield--error {
   .telia-textfield__label {
-    color: var(--red-600);
+    color: var(--text-input-error-label-color);
   }
 }
 
@@ -251,13 +248,13 @@ In case of changing back, keep this a couple of months
 .telia-textfield--grey {
   .telia-textfield__content {
     border: none;
-    background-color: var(--grey-100);
+    background-color: var(--text-input-disabled-background-color);
     input {
-      background-color: var(--grey-100);
+      background-color: var(--text-input-disabled-background-color);
     }
   }
   .telia-textfield__leftContent,
   .telia-textfield__rightContent {
-    background-color: var(--grey-100);
+    background-color: var(--text-input-disabled-background-color);
   }
 }

--- a/src/molecules/TextField/TextField.stories.tsx
+++ b/src/molecules/TextField/TextField.stories.tsx
@@ -29,7 +29,7 @@ export const Default = () => {
             success={state === 'success'}
             helpText={state === 'error' ? state : ''}
           />
-          <TextField label="Field label" helpText="Help or instrictions" />
+          <TextField label="Field label" helpText="Help or instructions" />
           <TextField label="Field label" helpText={<div style={{ textAlign: 'end' }}>Help on right side</div>} />
           <TextField label="Field label" error={true} helpText="Error message" />
           <TextField label="Field label" success={true} helpText="Success message" />
@@ -38,7 +38,7 @@ export const Default = () => {
           <TextField label="Field label" leftContent={<Icon icon="search" />} />
           <TextField
             label="Field label"
-            helpText="Help or instrictions"
+            helpText="Help or instructions"
             rightContent={<Button size="compact" kind="secondary-text" icon="close" onClick={action('button')} />}
           />
           <TextField label="Field label" helpText={<div style={{ textAlign: 'end' }}>Help on right side</div>} />
@@ -49,7 +49,7 @@ export const Default = () => {
           <TextField label="Field label" leftContent={<Icon icon="search" />} disabled={true} />
           <TextField
             label="Field label"
-            helpText="Help or instrictions"
+            helpText="Help or instructions"
             rightContent={
               <Button size="compact" kind="secondary-text" icon="close" onClick={action('button')} disabled={true} />
             }
@@ -57,7 +57,7 @@ export const Default = () => {
           />
           <TextField
             label="Field label"
-            helpText={<div style={{ textAlign: 'end' }}>Help or instrictions</div>}
+            helpText={<div style={{ textAlign: 'end' }}>Help or instructions</div>}
             disabled={true}
           />
         </div>
@@ -88,11 +88,11 @@ export const Compact = () => {
       <div style={{ display: 'flex' }}>
         <div style={{ width: '30%', marginRight: '1rem' }}>
           <TextField size="compact" label="Field label" placeholder="Placeholder text" />
-          <TextField size="compact" label="Field label" helpText="Help or instrictions" />
+          <TextField size="compact" label="Field label" helpText="Help or instructions" />
           <TextField
             size="compact"
             label="Field label"
-            helpText={<div style={{ textAlign: 'end' }}>Help or instrictions</div>}
+            helpText={<div style={{ textAlign: 'end' }}>Help or instructions</div>}
           />
           <TextField size="compact" label="Field label" error={true} helpText="Error message" />
           <TextField size="compact" label="Field label" success={true} helpText="Success message" />
@@ -102,13 +102,13 @@ export const Compact = () => {
           <TextField
             size="compact"
             label="Field label"
-            helpText="Help or instrictions"
+            helpText="Help or instructions"
             rightContent={<Button size="compact" kind="secondary-text" icon="close" onClick={action('button')} />}
           />
           <TextField
             size="compact"
             label="Field label"
-            helpText={<div style={{ textAlign: 'end' }}>Help or instrictions</div>}
+            helpText={<div style={{ textAlign: 'end' }}>Help or instructions</div>}
           />
           <TextField size="compact" label="Field label" error={true} helpText="Error message" />
           <TextField size="compact" label="Field label" success={true} helpText="Success message" />
@@ -118,7 +118,7 @@ export const Compact = () => {
           <TextField
             size="compact"
             label="Field label"
-            helpText="Help or instrictions"
+            helpText="Help or instructions"
             rightContent={
               <Button size="compact" kind="secondary-text" icon="close" onClick={action('button')} disabled={true} />
             }
@@ -127,7 +127,7 @@ export const Compact = () => {
           <TextField
             size="compact"
             label="Field label"
-            helpText={<div style={{ textAlign: 'end' }}>Help or instrictions</div>}
+            helpText={<div style={{ textAlign: 'end' }}>Help or instructions</div>}
             disabled={true}
           />
         </div>

--- a/src/molecules/TextField/TextField.tsx
+++ b/src/molecules/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, Ref, RefObject, useEffect, useRef, useState } from 'react';
+import React, { MutableRefObject, RefObject, useEffect, useRef, useState } from 'react';
 import cn from 'classnames';
 import { useFocus } from './useFocus';
 import { Icon } from '../../index';
@@ -116,6 +116,8 @@ export interface TextFieldProps {
   autoFocus?: boolean;
 
   dataTrackingId?: string;
+
+  required?: boolean;
 }
 
 export const TextField = (props: TextFieldProps) => {
@@ -186,6 +188,7 @@ export const TextField = (props: TextFieldProps) => {
             type={props.type || 'text'}
             placeholder={props.placeholder}
             disabled={props.disabled}
+            required={props.required}
             value={props.value}
             aria-label={props['aria-label']}
             aria-labelledby={inputLabelId}


### PR DESCRIPTION
- Datepicker inside `<form />` used to trigger form submit unnecessarily, because there were no `e.preventDefault()` in some callbacks or button did not have `type="text"`
- Removed  `postcss-custom-properties`. It was added 4 years ago and compiled css variables down to their values. But CSS variables have a wide brower support today, so there is no need to do that. 
- Extracted some component level css variables in order to enable theming datepicker and textinput locally in our project
- Added a paragraph about npm link

[draft pr at minside](https://github.com/telia-company/telia-no-min-side/pull/123)