### PR TITLE
Allow multiple lozenges in cart item

### DIFF
--- a/src/molecules/Lozenge/Lozenge.tsx
+++ b/src/molecules/Lozenge/Lozenge.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames';
 import React from 'react';
 import { Icon, IconDefinition } from '../../atoms/Icon';
 
-type Status = 'positive' | 'negative' | 'warning' | 'neutral' | 'communication' | 'info' | 'attention';
+export type LozengeStatus = 'positive' | 'negative' | 'warning' | 'neutral' | 'communication' | 'info' | 'attention';
 type Type = 'round' | 'square';
 
 export interface LozengeProps {
@@ -14,7 +14,7 @@ export interface LozengeProps {
    * The status style of the lozenge
    * @default "neutral"
    */
-  status?: Status;
+  status?: LozengeStatus;
   /**
    * The status style of the lozenge
    * @default "Round"

--- a/src/molecules/ShoppingCartV2/ShoppingCart.stories.tsx
+++ b/src/molecules/ShoppingCartV2/ShoppingCart.stories.tsx
@@ -599,7 +599,8 @@ export const subscriptionsWithDiscount = () => {
   };
 
   const groupContent: ICartItem[] = _.set(_.cloneDeep(subscriptionOnlyGroupContent), '[0].discount.types', [
-    { id: 'commitment', value: 150, text: 'Familierabatt' },
+    { id: 'commitment', value: 0, text: 'Dobbel data t.o.m 20.09.24', lozengeStatus: 'warning' },
+    { id: 'commitment', value: 150, text: 'Familierabatt', lozengeStatus: 'communication' },
   ]);
 
   return (

--- a/src/molecules/ShoppingCartV2/ShoppingCartItem.pcss
+++ b/src/molecules/ShoppingCartV2/ShoppingCartItem.pcss
@@ -6,10 +6,7 @@
     &__name-wrapper {
       display: flex;
       align-items: flex-start;
-
-      @media all and (max-width: 48em) {
-        flex-direction: column;
-      }
+      flex-direction: column;
     }
 
     &__link {
@@ -37,10 +34,7 @@
     &__discount-description {
       margin-right: 3.25rem;
       overflow: visible;
-
-      @media all and (min-width: 48em) {
-        margin-left: 1rem;
-      }
+      margin-top: 0.25rem;
     }
 
     &__name {

--- a/src/molecules/ShoppingCartV2/ShoppingCartItem.tsx
+++ b/src/molecules/ShoppingCartV2/ShoppingCartItem.tsx
@@ -246,18 +246,18 @@ interface CartItemNameProps {
 }
 
 const CartItemDiscount = ({ cartItem }: CartItemNameProps) => {
-  const discountType: ICartDiscountType | undefined = _.get(cartItem, 'discount.types[0]');
+  const discounts = cartItem.discount?.types || [];
 
   return (
     <>
-      {discountType && (
+      {discounts.map((discount) => (
         <Lozenge
           className="telia-shopping-cart__item__discount-description"
           type="square"
-          label={discountType.text}
-          status="communication"
+          label={discount.text}
+          status={discount.lozengeStatus || 'communication'}
         />
-      )}
+      ))}
     </>
   );
 };

--- a/src/molecules/ShoppingCartV2/types.ts
+++ b/src/molecules/ShoppingCartV2/types.ts
@@ -1,5 +1,6 @@
 import { IconDefinition } from '../../atoms/Icon/index';
 import { colors } from '../../utils/colors';
+import { LozengeStatus } from '../Lozenge/Lozenge';
 
 export type ICartType =
   | 'SUBSCRIPTION'
@@ -145,6 +146,7 @@ export interface ICartDiscountType {
   id: 'commitment' | 'sameGroup' | 'hardcoded';
   value: number;
   text: string;
+  lozengeStatus: LozengeStatus;
 }
 
 interface ICartItemDiscount {


### PR DESCRIPTION
https://trello.com/c/4UAnHy4R/4037-show-dobbel-data-in-cart

- Allow multiple lozenges in cart item
- Display them vertically both on mobile and desktop

| Before  | After  |
|---|---|
|![image](https://github.com/TeliaSoneraNorge/styleguide/assets/11172530/beb29bf4-86bf-49f4-a789-584d70ab6706)|![image](https://github.com/TeliaSoneraNorge/styleguide/assets/11172530/20544c5e-1e5c-40ac-92a6-a8e456bdf8ec)|