### PR TITLE
Adjust line height for min wcag size of clickable element

### DIFF
--- a/src/molecules/Footer/Footer.pcss
+++ b/src/molecules/Footer/Footer.pcss
@@ -82,6 +82,7 @@
             a {
                 display: block;
                 text-decoration: none;
+                line-height: 1.5rem
             }
         }
     }


### PR DESCRIPTION
WCAG requires minimum 24px height/width for clickable components.

Screen:
![Screenshot 2024-09-06 at 12 49 16](https://github.com/user-attachments/assets/1a3e0ba2-0954-4bd1-aa55-0d8c77b7cbac)
