### PR TITLE
NOCT-3322: Add disabled prop for side menu

### DIFF
--- a/src/molecules/SideMenu/SideMenu.pcss
+++ b/src/molecules/SideMenu/SideMenu.pcss
@@ -113,6 +113,13 @@
       &:hover {
         color: var(--core-purple-500);
       }
+      &--disabled {
+        color: var(--grey-300);
+        &:hover {
+          color: var(--grey-300);
+          cursor: default;
+        }
+      }
     }
     &__icon,
     &__avatar {

--- a/src/molecules/SideMenu/SideMenu.stories.tsx
+++ b/src/molecules/SideMenu/SideMenu.stories.tsx
@@ -337,6 +337,105 @@ export const WithoutCollapse = () => {
   );
 };
 
+export const WithDisabledItem = () => {
+  const [active, setActive] = useState(0);
+  enableTabKeyDetection();
+
+  return (
+    <>
+      <div style={{ display: 'flex', height: '90vh' }}>
+        <div style={{ marginRight: '1rem', height: '100%' }}>
+          <SideMenu aria-labelledby="main_menu">
+            <SideMenuTop>
+              <SideMenuItem
+                label="Rounded item"
+                avatar={{ img: b }}
+                onClick={action('user')}
+                color="grey"
+                kind="rounded"
+              />
+              <SideMenuItem label="Hjem" icon="home" onClick={() => setActive(0)} active={active === 0} href="/" />
+
+              <SideMenuItem
+                label="Abonnenter"
+                icon="user"
+                onClick={() => setActive(1)}
+                active={active === 1}
+                href="/abonnenter"
+                disabled
+              />
+              <SideMenuItem
+                hasNotification={true}
+                label={<div style={{ fontWeight: 'bold' }}>Økonomi</div>}
+                icon="money"
+                onClick={() => setActive(2)}
+                active={active === 2}
+                href="/okonomi"
+              />
+            </SideMenuTop>
+
+            <SideMenuBottom>
+              <SideMenuItem
+                label="Innstillinger"
+                icon="settings"
+                onClick={() => setActive(3)}
+                active={active === 3}
+                color="grey"
+              />
+              <SideMenuItem
+                label="Log ut"
+                icon="logout"
+                onClick={() => setActive(4)}
+                active={active === 4}
+                color="grey"
+              />
+              <SideMenuItem
+                kind="rounded"
+                label="Helene Grini"
+                avatar={{ text: 'HG' }}
+                onClick={action('user')}
+                color="grey"
+              />
+            </SideMenuBottom>
+          </SideMenu>
+        </div>
+        <div style={{ marginRight: '1rem', height: '100%' }}>
+          <SideMenu aria-labelledby="main_menu">
+            <SideMenuTop>
+              <SideMenuItem label="Hjem" icon="home" onClick={() => setActive(0)} active={active === 0} href="/" />
+              <SideMenuItem
+                label="Abonnenter"
+                icon="user"
+                onClick={() => setActive(1)}
+                active={active === 1}
+                href="/abonnenter"
+                disabled
+              />
+              <SideMenuItem
+                label="Økonomi"
+                icon="money"
+                onClick={() => setActive(2)}
+                active={active === 2}
+                href="/okonomi"
+              />
+            </SideMenuTop>
+          </SideMenu>
+        </div>
+        <div style={{ marginRight: '1rem', height: '100%' }}>
+          <SideMenu aria-labelledby="main_menu">
+            <SideMenuBottom>
+              <SideMenuItem label="Innstillinger" icon="settings" onClick={() => setActive(3)} active={active === 3} />
+              <SideMenuItem label="Log ut" icon="logout" onClick={() => setActive(4)} active={active === 4} />
+              <SideMenuItem label="Helene Grini" avatar={{ text: 'HG' }} onClick={action('user')} />
+            </SideMenuBottom>
+          </SideMenu>
+        </div>
+      </div>
+      <h4>Try to change the viewport size in the storybook toolbar </h4>
+    </>
+  );
+};
+
 export const WithItemGroup = () => {
   const [active, setActive] = useState(0);
   const [openGroup, setOpenGroup] = useState<'Subs' | 'Economy' | ''>('');

--- a/src/molecules/SideMenu/SideMenuItem.tsx
+++ b/src/molecules/SideMenu/SideMenuItem.tsx
@@ -62,6 +62,7 @@ type Props = {
    */
   collapse?: boolean;
   tabIndex?: number;
+  disabled?: boolean;
   dataTrackingId?: string;
   children?: React.ReactNode;
 };
@@ -83,13 +84,15 @@ export const SideMenuItem: React.FC<Props> = (props) => {
     tag,
     dataTrackingId,
     children,
+    disabled,
   } = props;
-  const Tag = href ? 'a' : 'button';
+  const Tag = disabled ? 'div' : href ? 'a' : 'button';
   const WrapperTag = tag ? tag : 'li';
   const collapse = props.collapse ?? true;
   const md = useBreakpoint('md');
 
   const handleClick = (e: React.SyntheticEvent) => {
+    if (disabled) return;
     if (href && onClick) {
       e.preventDefault();
     }
@@ -111,7 +114,9 @@ export const SideMenuItem: React.FC<Props> = (props) => {
     >
       {md || !collapse ? (
         <Tag
-          className="telia-side-menu-item__action-element"
+          className={`telia-side-menu-item__action-element ${
+            disabled && 'telia-side-menu-item__action-element--disabled'
+          }`}
           onClick={handleClick}
           href={href}
           tabIndex={tabIndex ?? 1}
@@ -136,7 +141,10 @@ export const SideMenuItem: React.FC<Props> = (props) => {
         </Tag>
       ) : (
         <Tag
-          className="telia-side-menu-item__action-element telia-side-menu-item__action-element--collapse"
+          className={`telia-side-menu-item__action-element telia-side-menu-item__action-element--collapse ${
+            disabled && 'telia-side-menu-item__action-element--disabled'
+          }
+          `}
           onClick={handleClick}
           tabIndex={tabIndex ?? 1}
           href={href}

--- a/src/molecules/SideMenu/SideMenuItem.tsx
+++ b/src/molecules/SideMenu/SideMenuItem.tsx
@@ -115,7 +115,7 @@ export const SideMenuItem: React.FC<Props> = (props) => {
       {md || !collapse ? (
         <Tag
           className={`telia-side-menu-item__action-element ${
-            disabled && 'telia-side-menu-item__action-element--disabled'
+            disabled ? 'telia-side-menu-item__action-element--disabled' : ''
           }`}
           onClick={handleClick}
           href={href}
@@ -142,7 +142,7 @@ export const SideMenuItem: React.FC<Props> = (props) => {
       ) : (
         <Tag
           className={`telia-side-menu-item__action-element telia-side-menu-item__action-element--collapse ${
-            disabled && 'telia-side-menu-item__action-element--disabled'
+            disabled ? 'telia-side-menu-item__action-element--disabled' : ''
           }
           `}
           onClick={handleClick}


### PR DESCRIPTION
We have a case where users don't have BankId of Temp access and therefore we want to limit their navigation through minside. Hence, we need to have a `disabled` state for SideMenuItem.