### PR TITLE
max-width for cartitem name

### DIFF
--- a/src/molecules/ShoppingCartV2/ShoppingCartItem.pcss
+++ b/src/molecules/ShoppingCartV2/ShoppingCartItem.pcss
@@ -31,6 +31,7 @@
     }
 
     &__name-wrapper {
+      max-width: 18rem;
       display: flex;
       align-items: flex-start;
       flex-direction: column;

--- a/src/organisms/SlidingShoppingCartV2/SlidingShoppingCartV2.stories.tsx
+++ b/src/organisms/SlidingShoppingCartV2/SlidingShoppingCartV2.stories.tsx
@@ -133,6 +133,7 @@ export const Default = () => {
           delivery={delivery}
           totalPriceFirstInvoice={priceFirstInvoice}
           totalPriceMonthly={pricePerMonth}
+          isAllowedToDelete
           monthlyPriceDetails={priceDetails}
           disclaimer={'Total telefonpris med SVITSJ i 24 md.: 16 056,-'}
           totalPriceUpfront={priceUpfront}


### PR DESCRIPTION
https://trello.com/c/7gUvmyw3/4989-langt-produktnavn-glir-over-slette-ikonet-p%C3%A5-desktop

<img width="492" alt="image" src="https://github.com/user-attachments/assets/017b86af-a8f9-455b-b940-51b24473f380" />
