### PR TITLE
Allow priceStriketrough at end

### DIFF
--- a/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.pcss
+++ b/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.pcss
@@ -214,9 +214,18 @@
     font-size: 1.5rem;
   }
 
+  &__price-suffix {
+    font-size: 1rem;
+    margin-left: 0.5rem;
+  }
+
   &__price-striketrough-wrapper {
     text-decoration-line: line-through;
     text-decoration-thickness: 1px;
+
+    &--right {
+      margin-left: 0.5rem;
+    }
   }
 
   &__price-striketrough {
@@ -327,7 +336,7 @@
 
   &__price-container-inner {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     justify-content: center;
   }
 

--- a/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.stories.tsx
+++ b/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.stories.tsx
@@ -496,3 +496,47 @@ export const DiscountInfo = () => {
     </SubscriptionCompactAccordion>
   );
 };
+
+export const WithPriceStrikethrough = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <SubscriptionCompactAccordion
+      name="Telia X - Normal"
+      title="20 Mbit/s"
+      id="smart20"
+      price={499}
+      priceStriketrough={699}
+      priceInfo={['/md.']}
+      isExpanded={isExpanded}
+      onOpen={() => {
+        setIsExpanded(!isExpanded);
+      }}
+    >
+      {CHILDREN}
+    </SubscriptionCompactAccordion>
+  );
+};
+
+export const WithPriceStrikethroughBack = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <SubscriptionCompactAccordion
+      name="Telia X - Normal"
+      title="20 Mbit/s"
+      id="smart20"
+      price={499}
+      priceSuffix="ord. pris"
+      priceStriketrough={699}
+      priceStriketroughPosition="right"
+      priceInfo={['/md.']}
+      isExpanded={isExpanded}
+      onOpen={() => {
+        setIsExpanded(!isExpanded);
+      }}
+    >
+      {CHILDREN}
+    </SubscriptionCompactAccordion>
+  );
+};

--- a/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.tsx
+++ b/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.tsx
@@ -28,7 +28,9 @@ export interface SubscriptionCompactAccordionProps {
   discountLine?: string;
   price: SubscriptionPrice;
   priceStriketrough?: SubscriptionPrice;
+  priceStriketroughPosition?: 'left' | 'right';
   priceStriketroughInfo?: string;
+  priceSuffix?: string;
   priceInfo?: string[];
   ribbon?: Ribbon | null;
   scrollToOnOpen?: boolean;
@@ -71,6 +73,8 @@ const SubscriptionCompactAccordion = ({
   familyDiscountInfoIcon = 'group',
   showChevron = true,
   footerRibbon,
+  priceSuffix,
+  priceStriketroughPosition = 'left',
 }: SubscriptionCompactAccordionProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -167,7 +171,7 @@ const SubscriptionCompactAccordion = ({
               )}
               <div className="subscription-compact-accordion__aside">
                 <div className="subscription-compact-accordion__price-container">
-                  {!!priceStriketrough && (
+                  {!!priceStriketrough && priceStriketroughPosition === 'left' && (
                     <div className="subscription-compact-accordion__price-striketrough-wrapper">
                       <span className="subscription-compact-accordion__price-striketrough">
                         {formatPrice(priceStriketrough)}
@@ -192,6 +196,17 @@ const SubscriptionCompactAccordion = ({
                           {info}
                         </span>
                       ))}
+                    {priceSuffix && <div className="subscription-compact-accordion__price-suffix">{priceSuffix}</div>}
+                    {!!priceStriketrough && priceStriketroughPosition === 'right' && (
+                      <div className="subscription-compact-accordion__price-striketrough-wrapper subscription-compact-accordion__price-striketrough-wrapper--right">
+                        <span className="subscription-compact-accordion__price-striketrough">
+                          {formatPrice(priceStriketrough)}
+                        </span>
+                        <span className="subscription-compact-accordion__price-striketrough-info">
+                          {priceStriketroughInfo}
+                        </span>
+                      </div>
+                    )}
                   </div>
                 </div>
                 {!!discountLine && (


### PR DESCRIPTION
Allow placing a suffix after price and allow placing priceStriketrough at end of line

### Screen
<img width="620" alt="Screenshot 2025-06-11 at 15 17 32" src="https://github.com/user-attachments/assets/55bb1819-9537-4da0-b618-734c13ae4f79" />
