### PR TITLE
Support dark-purple variant for SubscriptionCompactAccordion

### DIFF
--- a/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.pcss
+++ b/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.pcss
@@ -57,7 +57,8 @@
     width: 100%;
 
     &--black,
-    &--purple {
+    &--purple,
+    &--dark-purple {
       color: var(--white);
     }
   }
@@ -117,7 +118,8 @@
         &__heading-name,
         &__price {
           &--purple,
-          &--black {
+          &--black,
+          &--dark-purple {
             color: white;
           }
           color: #29003e;
@@ -126,7 +128,8 @@
 
       .subscription-compact-accordion__footer-container {
         &--purple,
-        &--black {
+        &--black,
+        &--dark-purple {
           hr {
             border-color: #d6d6dd !important;
           }
@@ -328,6 +331,34 @@
     .subscription-compact-accordion__heading-name,
     .subscription-compact-accordion__heading-striketrough {
       color: var(--white);
+    }
+  }
+
+  &--dark-purple {
+    .subscription-compact-accordion__header-first-row,
+    .subscription-compact-accordion__container-button {
+      border-radius: 0.5rem;
+      background-color: #29003e !important;
+      color: var(--white);
+      position: relative;
+
+      &:hover,
+      &:focus {
+        outline: none;
+        cursor: pointer;
+      }
+    }
+
+    .subscription-compact-accordion__icon-arrow,
+    .subscription-compact-accordion__heading-name,
+    .subscription-compact-accordion__heading-striketrough {
+      color: var(--white);
+    }
+
+    .subscription-compact-accordion__expanded-info {
+      background-color: #29003e;
+      color: var(--white);
+      fill: var(--white);
     }
   }
 

--- a/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.stories.tsx
+++ b/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.stories.tsx
@@ -406,6 +406,32 @@ export const Purple = () => {
   );
 };
 
+export const DarkPurple = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <SubscriptionCompactAccordion
+      name="Telia X - Normal"
+      title="20 Mbit/s"
+      id="smart20"
+      price={499}
+      footer={FOOTERCHILDREN}
+      priceInfo={['/md.']}
+      isExpanded={isExpanded}
+      onOpen={() => {
+        setIsExpanded(!isExpanded);
+      }}
+      variant="dark-purple"
+    >
+      <ul>
+        <li>Fri bruk av samtaler, SMS og MMS</li>
+        <li>Roam Like Home</li>
+      </ul>
+      <Button style={{ margin: '1.5rem 0' }} kind="voca-normal" text="Velg og fortsett"></Button>
+    </SubscriptionCompactAccordion>
+  );
+};
+
 export const WithFamilyDiscount = () => {
   const [isExpanded, setIsExpanded] = useState(false);
 

--- a/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.tsx
+++ b/src/molecules/SubscriptionCompactAccordion/SubscriptionCompactAccordion.tsx
@@ -43,7 +43,7 @@ export interface SubscriptionCompactAccordionProps {
   style?: React.CSSProperties;
   footer?: React.ReactNode;
   children?: React.ReactNode;
-  variant?: 'normal' | 'black' | 'purple';
+  variant?: 'normal' | 'black' | 'purple' | 'dark-purple';
   familyDiscountInfo?: string;
   familyDiscountInfoIcon?: IconDefinition;
   disountInfo?: React.ReactNode;
@@ -101,9 +101,11 @@ const SubscriptionCompactAccordion = ({
       className={cn('subscription-compact-accordion', className, {
         'subscription-compact-accordion--black': variant === 'black',
         'subscription-compact-accordion--purple': variant === 'purple',
+        'subscription-compact-accordion--dark-purple': variant === 'dark-purple',
         'subscription-compact-accordion-expanded': isExpanded,
         'subscription-compact-accordion-expanded-black': isExpanded && variant === 'black',
         'subscription-compact-accordion-expanded-purple': isExpanded && variant === 'purple',
+        'subscription-compact-accordion-expanded-dark-purple': isExpanded && variant === 'dark-purple',
       })}
     >
       <button
@@ -133,6 +135,7 @@ const SubscriptionCompactAccordion = ({
             className={cn('subscription-compact-accordion__name', {
               'subscription-compact-accordion__name--black': variant === 'black',
               'subscription-compact-accordion__name--purple': variant === 'purple',
+              'subscription-compact-accordion__name--dark-purple': variant === 'dark-purple',
             })}
           >
             {name}
@@ -149,6 +152,7 @@ const SubscriptionCompactAccordion = ({
                       className={cn('subscription-compact-accordion__heading-name', {
                         'subscription-compact-accordion__heading-name--purple': variant === 'purple',
                         'subscription-compact-accordion__heading-name--black': variant === 'black',
+                        'subscription-compact-accordion__heading-name--dark-purple': variant === 'dark-purple',
                       })}
                       tag="h2"
                       size="s"
@@ -161,6 +165,7 @@ const SubscriptionCompactAccordion = ({
                     className={cn('subscription-compact-accordion__heading-name', {
                       'subscription-compact-accordion__heading-name--purple': variant === 'purple',
                       'subscription-compact-accordion__heading-name--black': variant === 'black',
+                      'subscription-compact-accordion__heading-name--dark-purple': variant === 'dark-purple',
                     })}
                     tag="h2"
                     size="s"
@@ -193,6 +198,7 @@ const SubscriptionCompactAccordion = ({
                       className={cn('subscription-compact-accordion__price', {
                         'subscription-compact-accordion__price--purple': variant === 'purple',
                         'subscription-compact-accordion__price--black': variant === 'black',
+                        'subscription-compact-accordion__price--dark-purple': variant === 'dark-purple',
                       })}
                     >
                       {formatPrice(price)}
@@ -248,6 +254,7 @@ const SubscriptionCompactAccordion = ({
           <div
             className={cn('subscription-compact-accordion__footer-container', {
               'subscription-compact-accordion__footer-container--purple': variant === 'purple',
+              'subscription-compact-accordion__footer-container--dark-purple': variant === 'dark-purple',
               'subscription-compact-accordion__footer-container--black': variant === 'black',
             })}
           >
@@ -260,6 +267,7 @@ const SubscriptionCompactAccordion = ({
         <section
           className={cn('subscription-compact-accordion__expanded-info', {
             'subscription-compact-accordion__expanded-info--black': variant === 'black',
+            'subscription-compact-accordion__expanded-info--dark-purple': variant === 'dark-purple',
             'subscription-compact-accordion__expanded-info--purple': variant === 'purple',
           })}
         >
@@ -276,6 +284,7 @@ const SubscriptionCompactAccordion = ({
         className={cn('subscription-compact-accordion__footer-border', {
           'subscription-compact-accordion__footer-border--black': variant === 'black',
           'subscription-compact-accordion__footer-border--purple': variant === 'purple',
+          'subscription-compact-accordion__footer-border--dark-purple': variant === 'dark-purple',
         })}
       />
     </Tag>


### PR DESCRIPTION
Screens:
<img width="802" height="412" alt="Screenshot 2025-08-26 at 13 20 47" src="https://github.com/user-attachments/assets/1d823dd1-a4fd-43db-9ff9-fdb0ad78db55" />

<img width="721" height="510" alt="Screenshot 2025-08-26 at 13 20 51" src="https://github.com/user-attachments/assets/0620da08-8ad9-4e7c-87f2-58f0ed80618f" />

